### PR TITLE
feat!: Allow defining embedded modules in addition to embedded commands

### DIFF
--- a/builtin_command.go
+++ b/builtin_command.go
@@ -5,33 +5,23 @@ import (
 )
 
 type builtinCommand struct {
-	parent   Module
-	name     string
-	summary  string
-	help     string
-	exec     ExecFunc
-	complete CompleteFunc
+	parent     Module
+	definition *EmbeddedCommand
 }
-
-// ExecFunc is called when an built-in command is run.
-type ExecFunc func(e *Entrypoint, args, env []string) error
-
-// CompleteFunc is called when an built-in command is asked to supply shell completions.
-type CompleteFunc func(e *Entrypoint, args, env []string) ([]string, shellcomp.Directive, error)
 
 func (c *builtinCommand) Parent() Module           { return c.parent }
 func (c *builtinCommand) Path() string             { return c.parent.Path() }
-func (c *builtinCommand) Name() string             { return c.name }
-func (c *builtinCommand) Summary() (string, error) { return c.summary, nil }
-func (c *builtinCommand) Help() (string, error)    { return c.help, nil }
+func (c *builtinCommand) Name() string             { return c.definition.Name }
+func (c *builtinCommand) Summary() (string, error) { return c.definition.Summary, nil }
+func (c *builtinCommand) Help() (string, error)    { return c.definition.Help, nil }
 
 func (c *builtinCommand) Exec(e *Entrypoint, args, env []string) error {
-	return c.exec(e, args, env)
+	return c.definition.Exec(e, args, env)
 }
 
 func (c *builtinCommand) Complete(e *Entrypoint, args, env []string) ([]string, shellcomp.Directive, error) {
-	if c.complete != nil {
-		return c.complete(e, args, env)
+	if c.definition.Complete != nil {
+		return c.definition.Complete(e, args, env)
 	} else {
 		return []string{}, shellcomp.DirectiveNoFileComp, nil
 	}

--- a/builtin_module.go
+++ b/builtin_module.go
@@ -1,0 +1,26 @@
+package exoskeleton
+
+import (
+	"github.com/square/exoskeleton/pkg/shellcomp"
+)
+
+type builtinModule struct {
+	parent      Module
+	definition  *EmbeddedModule
+	subcommands Commands
+}
+
+func (m *builtinModule) Parent() Module           { return m.parent }
+func (m *builtinModule) Path() string             { return m.parent.Path() }
+func (m *builtinModule) Name() string             { return m.definition.Name }
+func (m *builtinModule) Summary() (string, error) { return m.definition.Summary, nil }
+func (m *builtinModule) Help() (string, error)    { return "", nil }
+func (m *builtinModule) Subcommands() Commands    { return m.subcommands }
+
+func (m *builtinModule) Exec(e *Entrypoint, args, env []string) error {
+	return e.printModuleHelp(m, args)
+}
+
+func (m *builtinModule) Complete(e *Entrypoint, args, env []string) ([]string, shellcomp.Directive, error) {
+	return m.Subcommands().completionsFor(args)
+}

--- a/commands_test.go
+++ b/commands_test.go
@@ -20,9 +20,9 @@ func TestFind(t *testing.T) {
 
 func TestFlatten(t *testing.T) {
 	a := &executable{name: "a"}
-	b := &module{executable: executable{name: "b"}}
+	b := &directoryModule{executable: executable{name: "b"}}
 	c := &executable{parent: b, name: "c"}
-	d := &module{executable: executable{parent: b, name: "d"}}
+	d := &directoryModule{executable: executable{parent: b, name: "d"}}
 	e := &executable{parent: d, name: "e"}
 	b.cmds = Commands{c, d}
 	d.cmds = Commands{e}

--- a/commands_test.go
+++ b/commands_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestFind(t *testing.T) {
-	a := &executable{name: "a"}
-	b := &executable{name: "b"}
+	a := &executableCommand{name: "a"}
+	b := &executableCommand{name: "b"}
 	// Should never be returned because `a` precedes it.
-	overloaded_a := &executable{name: "a"}
+	overloaded_a := &executableCommand{name: "a"}
 	cmds := Commands{a, b, overloaded_a}
 
 	assert.Equal(t, a, cmds.Find("a"))
@@ -19,11 +19,11 @@ func TestFind(t *testing.T) {
 }
 
 func TestFlatten(t *testing.T) {
-	a := &executable{name: "a"}
-	b := &directoryModule{executable: executable{name: "b"}}
-	c := &executable{parent: b, name: "c"}
-	d := &directoryModule{executable: executable{parent: b, name: "d"}}
-	e := &executable{parent: d, name: "e"}
+	a := &executableCommand{name: "a"}
+	b := &directoryModule{executableCommand: executableCommand{name: "b"}}
+	c := &executableCommand{parent: b, name: "c"}
+	d := &directoryModule{executableCommand: executableCommand{parent: b, name: "d"}}
+	e := &executableCommand{parent: d, name: "e"}
 	b.cmds = Commands{c, d}
 	d.cmds = Commands{e}
 

--- a/completions_test.go
+++ b/completions_test.go
@@ -15,7 +15,7 @@ func TestCompletionsFor(t *testing.T) {
 	//     ├── lock
 	//     └── unlock
 	entrypoint := &Entrypoint{}
-	echo := &builtinCommand{parent: entrypoint, name: "echo", complete: echoArgs}
+	echo := &builtinCommand{parent: entrypoint, definition: &EmbeddedCommand{Name: "echo", Complete: echoArgs}}
 	sfoils := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "s-foils"}}
 	lock := &executableCommand{parent: sfoils, name: "lock"}
 	unlock := &executableCommand{parent: sfoils, name: "unlock"}

--- a/completions_test.go
+++ b/completions_test.go
@@ -16,9 +16,9 @@ func TestCompletionsFor(t *testing.T) {
 	//     └── unlock
 	entrypoint := &Entrypoint{}
 	echo := &builtinCommand{parent: entrypoint, name: "echo", complete: echoArgs}
-	sfoils := &directoryModule{executable: executable{parent: entrypoint, name: "s-foils"}}
-	lock := &executable{parent: sfoils, name: "lock"}
-	unlock := &executable{parent: sfoils, name: "unlock"}
+	sfoils := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "s-foils"}}
+	lock := &executableCommand{parent: sfoils, name: "lock"}
+	unlock := &executableCommand{parent: sfoils, name: "unlock"}
 	sfoils.cmds = Commands{lock, unlock}
 	entrypoint.cmds = Commands{echo, sfoils}
 

--- a/completions_test.go
+++ b/completions_test.go
@@ -16,7 +16,7 @@ func TestCompletionsFor(t *testing.T) {
 	//     └── unlock
 	entrypoint := &Entrypoint{}
 	echo := &builtinCommand{parent: entrypoint, name: "echo", complete: echoArgs}
-	sfoils := &module{executable: executable{parent: entrypoint, name: "s-foils"}}
+	sfoils := &directoryModule{executable: executable{parent: entrypoint, name: "s-foils"}}
 	lock := &executable{parent: sfoils, name: "lock"}
 	unlock := &executable{parent: sfoils, name: "unlock"}
 	sfoils.cmds = Commands{lock, unlock}

--- a/directory_module.go
+++ b/directory_module.go
@@ -8,7 +8,7 @@ import (
 )
 
 type directoryModule struct {
-	executable
+	executableCommand
 	cmds       Commands
 	discoverer *discoverer
 }

--- a/directory_module.go
+++ b/directory_module.go
@@ -1,0 +1,48 @@
+package exoskeleton
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/square/exoskeleton/pkg/shellcomp"
+)
+
+type directoryModule struct {
+	executable
+	cmds       Commands
+	discoverer *discoverer
+}
+
+func (m *directoryModule) Exec(e *Entrypoint, args, env []string) error {
+	return e.printModuleHelp(m, args)
+}
+
+func (m *directoryModule) Complete(_ *Entrypoint, args, _ []string) ([]string, shellcomp.Directive, error) {
+	return m.Subcommands().completionsFor(args)
+}
+
+func (m *directoryModule) Summary() (string, error) {
+	return getMessageFromDir(m.path, "summary")
+}
+
+func (m *directoryModule) Help() (string, error) {
+	return getMessageFromDir(m.path, "help")
+}
+
+func (m *directoryModule) Subcommands() Commands {
+	if m.cmds == nil {
+		m.discoverer.discoverIn(filepath.Dir(m.path), m, &m.cmds)
+	}
+
+	return m.cmds
+}
+
+func getMessageFromDir(path string, flag string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	return getMessageFromMagicComments(f, flag)
+}

--- a/discovery.go
+++ b/discovery.go
@@ -53,7 +53,7 @@ func (d *discoverer) discoverIn(p string, parent Module, all *Commands) {
 			// or that don't contain the configured modulefile.
 			if (d.maxDepth == -1 || d.depth < d.maxDepth) && exists(modulefilePath) {
 				*all = append(*all, &directoryModule{
-					executable: executable{
+					executableCommand: executableCommand{
 						parent:       parent,
 						path:         modulefilePath,
 						name:         name,
@@ -71,7 +71,7 @@ func (d *discoverer) discoverIn(p string, parent Module, all *Commands) {
 		} else if ok, err := isExecutable(file); err != nil {
 			d.onError(DiscoveryError{Cause: err, Path: p})
 		} else if ok {
-			*all = append(*all, &executable{
+			*all = append(*all, &executableCommand{
 				parent:       parent,
 				path:         path.Join(p, name),
 				name:         name,

--- a/discovery.go
+++ b/discovery.go
@@ -10,7 +10,7 @@ import (
 type discoverer struct {
 	maxDepth   int
 	depth      int
-	onError    ErrorFunc
+	onError    func(error)
 	modulefile string
 }
 

--- a/discovery.go
+++ b/discovery.go
@@ -52,7 +52,7 @@ func (d *discoverer) discoverIn(p string, parent Module, all *Commands) {
 			// Don't search directories that exceed the configured maxDepth
 			// or that don't contain the configured modulefile.
 			if (d.maxDepth == -1 || d.depth < d.maxDepth) && exists(modulefilePath) {
-				*all = append(*all, &module{
+				*all = append(*all, &directoryModule{
 					executable: executable{
 						parent:       parent,
 						path:         modulefilePath,

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -61,9 +61,26 @@ func New(paths []string, options ...Option) (*Entrypoint, error) {
 	options =
 		append(
 			options,
-			PrependCommand(`help`, "", fmt.Sprintf(self.helpHelp, self.Name()), helpExec, CompleteCommands),
-			PrependCommand(`which`, "", fmt.Sprintf(self.whichHelp, self.Name()), whichExec, CompleteCommands),
-			PrependCommand(`complete`, "", fmt.Sprintf(self.completeHelp, self.Name()), completeExec, nil),
+			PrependCommands(
+				&EmbeddedCommand{
+					Name:     "help",
+					Help:     fmt.Sprintf(self.helpHelp, self.Name()),
+					Exec:     helpExec,
+					Complete: CompleteCommands,
+				},
+				&EmbeddedCommand{
+					Name:     "which",
+					Help:     fmt.Sprintf(self.whichHelp, self.Name()),
+					Exec:     whichExec,
+					Complete: CompleteCommands,
+				},
+				&EmbeddedCommand{
+					Name:     "complete",
+					Help:     fmt.Sprintf(self.completeHelp, self.Name()),
+					Exec:     completeExec,
+					Complete: nil,
+				},
+			),
 		)
 
 	for _, op := range options {

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -9,10 +9,10 @@ import (
 )
 
 // CommandNotFoundFunc is a function that accepts a Null Command object. It is called when a command is not found.
-type CommandNotFoundFunc func(Command)
+type CommandNotFoundFunc func(*Entrypoint, Command)
 
 // ErrorFunc is called when an error occurs.
-type ErrorFunc func(error)
+type ErrorFunc func(*Entrypoint, error)
 
 // MenuHeadingForFunc is a function that is expected to return the heading
 // under which a command should be listed when it is printed in a menu.
@@ -124,13 +124,13 @@ func newWithDefaults(path string) *Entrypoint {
 
 func (e *Entrypoint) onError(err error) {
 	for _, callback := range e.errorCallbacks {
-		callback(err)
+		callback(e, err)
 	}
 }
 
 func (e *Entrypoint) commandNotFound(cmd nullCommand) {
 	for _, callback := range e.commandNotFoundCallbacks {
-		callback(cmd)
+		callback(e, cmd)
 	}
 
 	usage := UsageRelativeTo(cmd, e)

--- a/executable_command.go
+++ b/executable_command.go
@@ -13,21 +13,21 @@ import (
 	"github.com/square/exoskeleton/pkg/shellcomp"
 )
 
-// executable implements the Command interface for a file that can be executed.
-type executable struct {
+// executableCommand implements the Command interface for a file that can be executed.
+type executableCommand struct {
 	parent       Module
 	path         string
 	name         string
 	discoveredIn string
 }
 
-func (cmd *executable) Parent() Module       { return cmd.parent }
-func (cmd *executable) Path() string         { return cmd.path }
-func (cmd *executable) Name() string         { return cmd.name }
-func (cmd *executable) DiscoveredIn() string { return cmd.discoveredIn }
+func (cmd *executableCommand) Parent() Module       { return cmd.parent }
+func (cmd *executableCommand) Path() string         { return cmd.path }
+func (cmd *executableCommand) Name() string         { return cmd.name }
+func (cmd *executableCommand) DiscoveredIn() string { return cmd.discoveredIn }
 
 // Exec invokes the executable with the given arguments and environment.
-func (cmd *executable) Exec(_ *Entrypoint, args, env []string) error {
+func (cmd *executableCommand) Exec(_ *Entrypoint, args, env []string) error {
 	command := exec.Command(cmd.path, args...)
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
@@ -49,7 +49,7 @@ func (cmd *executable) Exec(_ *Entrypoint, args, env []string) error {
 
 // Complete invokes the executable with `--complete` as its first argument
 // and parses its output according to Cobra's ShellComp API.
-func (cmd *executable) Complete(_ *Entrypoint, args, env []string) ([]string, shellcomp.Directive, error) {
+func (cmd *executableCommand) Complete(_ *Entrypoint, args, env []string) ([]string, shellcomp.Directive, error) {
 	command := exec.Command(cmd.path, append([]string{"--complete", "--"}, args...)...)
 	command.Stdin = nil
 	command.Stderr = nil
@@ -71,7 +71,7 @@ func (cmd *executable) Complete(_ *Entrypoint, args, env []string) ([]string, sh
 // When Command is a binary, it executes the command with the flag '--summary'.
 // The executable is expected to write the summary to standard output and exit
 // successfully.
-func (cmd *executable) Summary() (string, error) {
+func (cmd *executableCommand) Summary() (string, error) {
 	return getMessageFromCommand(cmd, "summary")
 }
 
@@ -83,7 +83,7 @@ func (cmd *executable) Summary() (string, error) {
 // When Command is a binary, it executes the command with the flag '--help'.
 // The executable is expected to write the help text to standard output and exit
 // successfully.
-func (cmd *executable) Help() (string, error) {
+func (cmd *executableCommand) Help() (string, error) {
 	return getMessageFromCommand(cmd, "help")
 }
 
@@ -116,7 +116,7 @@ const (
 	unknown
 )
 
-func getMessageFromCommand(cmd *executable, message string) (string, error) {
+func getMessageFromCommand(cmd *executableCommand, message string) (string, error) {
 	f, err := os.Open(cmd.path)
 	if err != nil {
 		return "", err

--- a/identification_test.go
+++ b/identification_test.go
@@ -32,16 +32,16 @@ func TestIdentify(t *testing.T) {
 	//     ├── c
 	//     └── d
 	//         └── e
-	a := &executable{name: "a"}
-	b := &directoryModule{executable: executable{name: "b"}}
-	c := &executable{parent: b, name: "c"}
-	d := &directoryModule{executable: executable{parent: b, name: "d"}}
-	e := &executable{parent: d, name: "e"}
+	a := &executableCommand{name: "a"}
+	b := &directoryModule{executableCommand: executableCommand{name: "b"}}
+	c := &executableCommand{parent: b, name: "c"}
+	d := &directoryModule{executableCommand: executableCommand{parent: b, name: "d"}}
+	e := &executableCommand{parent: d, name: "e"}
 	b.cmds = Commands{c, d}
 	d.cmds = Commands{e}
 
 	// Should never be returned because `a` precedes it.
-	overloaded_a := &executable{name: "a"}
+	overloaded_a := &executableCommand{name: "a"}
 
 	help := &builtinCommand{name: `help`}
 	entrypoint := &Entrypoint{cmds: Commands{help, a, b, overloaded_a}}

--- a/identification_test.go
+++ b/identification_test.go
@@ -33,9 +33,9 @@ func TestIdentify(t *testing.T) {
 	//     └── d
 	//         └── e
 	a := &executable{name: "a"}
-	b := &module{executable: executable{name: "b"}}
+	b := &directoryModule{executable: executable{name: "b"}}
 	c := &executable{parent: b, name: "c"}
-	d := &module{executable: executable{parent: b, name: "d"}}
+	d := &directoryModule{executable: executable{parent: b, name: "d"}}
 	e := &executable{parent: d, name: "e"}
 	b.cmds = Commands{c, d}
 	d.cmds = Commands{e}

--- a/identification_test.go
+++ b/identification_test.go
@@ -43,7 +43,7 @@ func TestIdentify(t *testing.T) {
 	// Should never be returned because `a` precedes it.
 	overloaded_a := &executableCommand{name: "a"}
 
-	help := &builtinCommand{name: `help`}
+	help := &builtinCommand{definition: &EmbeddedCommand{Name: `help`}}
 	entrypoint := &Entrypoint{cmds: Commands{help, a, b, overloaded_a}}
 
 	scenarios := []struct {

--- a/menu.go
+++ b/menu.go
@@ -140,7 +140,7 @@ func (mi *menuItem) String() string {
 type summaryCache struct {
 	Path    string
 	data    *cache
-	onError ErrorFunc
+	onError func(error)
 }
 
 type cache struct {

--- a/menu_test.go
+++ b/menu_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestBuildMenuUsage(t *testing.T) {
 	entrypoint := &Entrypoint{name: "entrypoint"}
-	module := &module{executable: executable{parent: entrypoint, name: "module"}}
+	module := &directoryModule{executable: executable{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
 	assert.Equal(t, "entrypoint <command> [<args>]", entrypoint.buildMenu(entrypoint.cmds, entrypoint).Usage)
@@ -22,7 +22,7 @@ func TestBuildMenuUsage(t *testing.T) {
 
 func TestBuildMenuTrailer(t *testing.T) {
 	entrypoint := &Entrypoint{name: "entrypoint"}
-	module := &module{executable: executable{parent: entrypoint, name: "module"}}
+	module := &directoryModule{executable: executable{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
 	assert.Equal(t,

--- a/menu_test.go
+++ b/menu_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestBuildMenuUsage(t *testing.T) {
 	entrypoint := &Entrypoint{name: "entrypoint"}
-	module := &directoryModule{executable: executable{parent: entrypoint, name: "module"}}
+	module := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
 	assert.Equal(t, "entrypoint <command> [<args>]", entrypoint.buildMenu(entrypoint.cmds, entrypoint).Usage)
@@ -22,7 +22,7 @@ func TestBuildMenuUsage(t *testing.T) {
 
 func TestBuildMenuTrailer(t *testing.T) {
 	entrypoint := &Entrypoint{name: "entrypoint"}
-	module := &directoryModule{executable: executable{parent: entrypoint, name: "module"}}
+	module := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
 	assert.Equal(t,
@@ -53,7 +53,7 @@ func TestBuildMenuSectionsUncached(t *testing.T) {
 
 func TestBuildMenuSectionsReadFromCache(t *testing.T) {
 	entrypoint := newWithDefaults("/entrypoint")
-	cmd := &executable{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
+	cmd := &executableCommand{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
 	modTime, err := modTime(cmd)
 	if err != nil {
 		t.Error(err)
@@ -75,7 +75,7 @@ func TestBuildMenuSectionsReadFromCache(t *testing.T) {
 
 func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 	entrypoint := newWithDefaults("/entrypoint")
-	cmd := &executable{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
+	cmd := &executableCommand{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
 	modTime, err := modTime(cmd)
 	if err != nil {
 		t.Error(err)
@@ -103,7 +103,7 @@ func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 
 func TestBuildMenuSectionsWriteToCacheWhenMissing(t *testing.T) {
 	entrypoint := newWithDefaults("/entrypoint")
-	cmd := &executable{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
+	cmd := &executableCommand{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
 	modTime, err := modTime(cmd)
 	if err != nil {
 		t.Error(err)

--- a/module.go
+++ b/module.go
@@ -1,12 +1,5 @@
 package exoskeleton
 
-import (
-	"os"
-	"path/filepath"
-
-	"github.com/square/exoskeleton/pkg/shellcomp"
-)
-
 // Module is a namespace of commands in your CLI application.
 //
 // In the Go CLI, 'go mod tidy' is a command. Exoskeleton would module 'mod'
@@ -21,44 +14,4 @@ type Module interface {
 	// For example, in the Go CLI, 'go mod' is a Module and its Subcommands would
 	// be 'download', 'edit', 'graph', 'init', 'tidy', 'vendor', 'verify', and 'why'.
 	Subcommands() Commands
-}
-
-type module struct {
-	executable
-	cmds       Commands
-	discoverer *discoverer
-}
-
-func (m *module) Exec(e *Entrypoint, args, env []string) error {
-	return e.printModuleHelp(m, args)
-}
-
-func (m *module) Complete(_ *Entrypoint, args, _ []string) ([]string, shellcomp.Directive, error) {
-	return m.Subcommands().completionsFor(args)
-}
-
-func (m *module) Summary() (string, error) {
-	return getMessageFromDir(m.path, "summary")
-}
-
-func (m *module) Help() (string, error) {
-	return getMessageFromDir(m.path, "help")
-}
-
-func (m *module) Subcommands() Commands {
-	if m.cmds == nil {
-		m.discoverer.discoverIn(filepath.Dir(m.path), m, &m.cmds)
-	}
-
-	return m.cmds
-}
-
-func getMessageFromDir(path string, flag string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	return getMessageFromMagicComments(f, flag)
 }

--- a/null_command_test.go
+++ b/null_command_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestIsNull(t *testing.T) {
 	assert.True(t, IsNull(nullCommand{}))
-	assert.False(t, IsNull(&executable{}))
+	assert.False(t, IsNull(&executableCommand{}))
 	assert.False(t, IsNull(&builtinCommand{}))
 }

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestSuggestionsFor(t *testing.T) {
 	entrypoint := &Entrypoint{name: "e"}
-	spec := &directoryModule{executable: executable{parent: entrypoint, name: "spec"}}
-	echoargs := &executable{parent: spec, name: "echoargs"}
+	spec := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "spec"}}
+	echoargs := &executableCommand{parent: spec, name: "echoargs"}
 	spec.cmds = Commands{echoargs}
 	// Should never be returned because `spec` precedes it.
-	overloaded_spec := &executable{parent: entrypoint, name: "spec"}
+	overloaded_spec := &executableCommand{parent: entrypoint, name: "spec"}
 	entrypoint.cmds = Commands{spec, overloaded_spec}
 
 	scenarios := []struct {

--- a/suggestions_test.go
+++ b/suggestions_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSuggestionsFor(t *testing.T) {
 	entrypoint := &Entrypoint{name: "e"}
-	spec := &module{executable: executable{parent: entrypoint, name: "spec"}}
+	spec := &directoryModule{executable: executable{parent: entrypoint, name: "spec"}}
 	echoargs := &executable{parent: spec, name: "echoargs"}
 	spec.cmds = Commands{echoargs}
 	// Should never be returned because `spec` precedes it.

--- a/usage_test.go
+++ b/usage_test.go
@@ -11,9 +11,9 @@ func TestUsageRelativeTo(t *testing.T) {
 	// └── a
 	//     └── b
 	//         └── c
-	a := &directoryModule{executable: executable{parent: entrypoint, name: "a"}}
-	b := &directoryModule{executable: executable{parent: a, name: "b"}}
-	c := &executable{parent: b, name: "c"}
+	a := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "a"}}
+	b := &directoryModule{executableCommand: executableCommand{parent: a, name: "b"}}
+	c := &executableCommand{parent: b, name: "c"}
 	a.cmds = Commands{b}
 	b.cmds = Commands{c}
 	entrypoint.cmds = Commands{a}

--- a/usage_test.go
+++ b/usage_test.go
@@ -11,8 +11,8 @@ func TestUsageRelativeTo(t *testing.T) {
 	// └── a
 	//     └── b
 	//         └── c
-	a := &module{executable: executable{parent: entrypoint, name: "a"}}
-	b := &module{executable: executable{parent: a, name: "b"}}
+	a := &directoryModule{executable: executable{parent: entrypoint, name: "a"}}
+	b := &directoryModule{executable: executable{parent: a, name: "b"}}
 	c := &executable{parent: b, name: "c"}
 	a.cmds = Commands{b}
 	b.cmds = Commands{c}


### PR DESCRIPTION
#### Summary of Changes

1. Rename `executable` to `executableCommand` and `module` to `directoryModule` so that all the concrete implementations of `Command` and `Module` are named `adjective`+`Interface`
2. (BREAKING) Change `AppendCommand` and `PrependCommand` to accept a struct defining the new embedded commands instead of a loose collection of positional arguments. AND Change both methods to accept any number of those structs.
3. (FEATURE) Allow `AppendCommands` and `PrependCommands` to define new embedded _modules_ in addition to embedded commands.