### PR TITLE
refactor: Export the function that builds a menu from a set of commands

### DIFF
--- a/help_cmd.go
+++ b/help_cmd.go
@@ -75,7 +75,7 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 		cmds = e.expandModules(cmds)
 	}
 
-	return e.buildMenu(cmds, m).String(), nil
+	return e.MenuRelativeTo(cmds, m).String(), nil
 }
 
 func (e *Entrypoint) expandModules(cmds Commands) Commands {

--- a/menu_test.go
+++ b/menu_test.go
@@ -11,30 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildMenuUsage(t *testing.T) {
+func TestMenuUsage(t *testing.T) {
 	entrypoint := &Entrypoint{name: "entrypoint"}
 	module := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
-	assert.Equal(t, "entrypoint <command> [<args>]", entrypoint.buildMenu(entrypoint.cmds, entrypoint).Usage)
-	assert.Equal(t, "entrypoint module <command> [<args>]", entrypoint.buildMenu(module.cmds, module).Usage)
+	assert.Equal(t, "entrypoint <command> [<args>]", entrypoint.MenuRelativeTo(entrypoint.cmds, entrypoint).Usage)
+	assert.Equal(t, "entrypoint module <command> [<args>]", entrypoint.MenuRelativeTo(module.cmds, module).Usage)
 }
 
-func TestBuildMenuTrailer(t *testing.T) {
+func TestMenuTrailer(t *testing.T) {
 	entrypoint := &Entrypoint{name: "entrypoint"}
 	module := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
 	assert.Equal(t,
 		"Run \033[96mentrypoint help <command>\033[0m to print information on a specific command.",
-		entrypoint.buildMenu(entrypoint.cmds, entrypoint).Trailer)
+		entrypoint.MenuRelativeTo(entrypoint.cmds, entrypoint).Trailer)
 
 	assert.Equal(t,
 		"Run \033[96mentrypoint help module <command>\033[0m to print information on a specific command.",
-		entrypoint.buildMenu(module.cmds, module).Trailer)
+		entrypoint.MenuRelativeTo(module.cmds, module).Trailer)
 }
 
-func TestBuildMenuSectionsUncached(t *testing.T) {
+func TestMenuSectionsUncached(t *testing.T) {
 	entrypoint, err := New([]string{fixtures})
 	entrypoint.cachePath = ""
 	if err != nil {
@@ -49,10 +49,10 @@ func TestBuildMenuSectionsUncached(t *testing.T) {
    go:       Provides several commands
    hello     Prints "hello"
    suggest   Suggests arguments`,
-		nocolor(entrypoint.buildMenu(entrypoint.cmds, entrypoint).Sections.String()))
+		nocolor(entrypoint.MenuRelativeTo(entrypoint.cmds, entrypoint).Sections.String()))
 }
 
-func TestBuildMenuSectionsReadFromCache(t *testing.T) {
+func TestMenuSectionsReadFromCache(t *testing.T) {
 	entrypoint := newWithDefaults("/entrypoint")
 	cmd := &executableCommand{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
 	modTime, err := modTime(cmd)
@@ -71,10 +71,10 @@ func TestBuildMenuSectionsReadFromCache(t *testing.T) {
 
 	assert.Equal(t,
 		"COMMANDS\n   echoargs  CACHED SUMMARY",
-		nocolor(entrypoint.buildMenu(entrypoint.cmds, entrypoint).Sections.String()))
+		nocolor(entrypoint.MenuRelativeTo(entrypoint.cmds, entrypoint).Sections.String()))
 }
 
-func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
+func TestMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 	entrypoint := newWithDefaults("/entrypoint")
 	cmd := &executableCommand{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
 	modTime, err := modTime(cmd)
@@ -93,7 +93,7 @@ func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 
 	assert.Equal(t,
 		"COMMANDS\n   echoargs  Echoes the args it received",
-		nocolor(entrypoint.buildMenu(entrypoint.cmds, entrypoint).Sections.String()))
+		nocolor(entrypoint.MenuRelativeTo(entrypoint.cmds, entrypoint).Sections.String()))
 
 	f.Seek(0, 0)
 	buf := new(bytes.Buffer)
@@ -102,7 +102,7 @@ func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"Echoes the args it received"}}}`, modTime), buf.String())
 }
 
-func TestBuildMenuSectionsWriteToCacheWhenMissing(t *testing.T) {
+func TestMenuSectionsWriteToCacheWhenMissing(t *testing.T) {
 	entrypoint := newWithDefaults("/entrypoint")
 	cmd := &executableCommand{parent: entrypoint, path: filepath.Join(fixtures, "echoargs"), name: "echoargs"}
 	modTime, err := modTime(cmd)
@@ -121,7 +121,7 @@ func TestBuildMenuSectionsWriteToCacheWhenMissing(t *testing.T) {
 
 	assert.Equal(t,
 		"COMMANDS\n   echoargs  Echoes the args it received",
-		nocolor(entrypoint.buildMenu(entrypoint.cmds, entrypoint).Sections.String()))
+		nocolor(entrypoint.MenuRelativeTo(entrypoint.cmds, entrypoint).Sections.String()))
 
 	f.Seek(0, 0)
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Renames `buildMenu` to `MenuRelativeTo` and exports all the menu objects

This allows exoskeleton instances to write their own Help commands.

In the future, I think `exoskeleton` should have hooks for customizing the menu (like a `HelpFormatter` function or a `HelpTemplate`) but I'm not quite sure about their shapes yet. Letting an exoskeleton application implement its own help function is the lowest level where an application can customize the help and this change affords that.