### PR TITLE
feat!: Pass `Entrypoint` to the callbacks that are registered during Entrypoint's initialization

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -10,7 +10,7 @@ import (
 type discoverer struct {
 	maxDepth   int
 	depth      int
-	onError    ErrorFunc
+	onError    func(error)
 	modulefile string
 }
 

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -9,10 +9,10 @@ import (
 )
 
 // CommandNotFoundFunc is a function that accepts a Null Command object. It is called when a command is not found.
-type CommandNotFoundFunc func(Command)
+type CommandNotFoundFunc func(*Entrypoint, Command)
 
 // ErrorFunc is called when an error occurs.
-type ErrorFunc func(error)
+type ErrorFunc func(*Entrypoint, error)
 
 // MenuHeadingForFunc is a function that is expected to return the heading
 // under which a command should be listed when it is printed in a menu.
@@ -124,13 +124,13 @@ func newWithDefaults(path string) *Entrypoint {
 
 func (e *Entrypoint) onError(err error) {
 	for _, callback := range e.errorCallbacks {
-		callback(err)
+		callback(e, err)
 	}
 }
 
 func (e *Entrypoint) commandNotFound(cmd nullCommand) {
 	for _, callback := range e.commandNotFoundCallbacks {
-		callback(cmd)
+		callback(e, cmd)
 	}
 
 	usage := UsageRelativeTo(cmd, e)

--- a/menu.go
+++ b/menu.go
@@ -140,7 +140,7 @@ func (mi *menuItem) String() string {
 type summaryCache struct {
 	Path    string
 	data    *cache
-	onError ErrorFunc
+	onError func(error)
 }
 
 type cache struct {


### PR DESCRIPTION
As these callbacks are passed to the `Entrypoint`'s constructor, they won't have access to the `Entrypoint`'s instance unless it is passed in (or unless the client assigns it to a global variable).