### PR TITLE
fix: Capture only standard output from invocations using `--summary` and `--help`

### DIFF
--- a/executable_command.go
+++ b/executable_command.go
@@ -214,10 +214,10 @@ func getHelpFromMagicComments(reader *bufio.Reader) (string, error) {
 
 func getMessageFromExecution(path string, flag string) (string, error) {
 	cmd := exec.Command(path, "--"+flag)
-	out, err := cmd.CombinedOutput()
+	cmd.Stderr = nil
+	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to execute %s: %v", path, err)
+		err = fmt.Errorf("failed to execute %s: %w", path, err)
 	}
-
-	return strings.TrimSuffix(string(out), "\n"), nil
+	return strings.TrimSuffix(string(out), "\n"), err
 }

--- a/executable_command_test.go
+++ b/executable_command_test.go
@@ -1,0 +1,20 @@
+package exoskeleton
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMessageFromExecution(t *testing.T) {
+	path := filepath.Join(fixtures, "edge-cases", "summary-fail")
+	summary, err := getMessageFromExecution(path, "summary")
+
+	var ee *exec.ExitError
+
+	assert.Equal(t, "out", summary)
+	assert.ErrorAs(t, err, &ee)
+	assert.Equal(t, "err\n", string(ee.Stderr))
+}

--- a/fixtures/edge-cases/summary-fail
+++ b/fixtures/edge-cases/summary-fail
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+for arg in "$@"; do
+  if [ "$arg" = "--summary" ]; then
+    echo 'err' >&2
+    echo 'out'
+    exit 1
+  fi
+done
+
+printf "hello"


### PR DESCRIPTION
Instead of using `CombinedOutput` and treating standard error as part of a subcommand's summary or help, treat only the standard output as the value. Meanwhile, make the standard error available  if the subcommand exits unsuccessfully.