### PR TITLE
feat: Define a contract that allows a single executable to represent a subtree of commands

### DIFF
--- a/discovery_test.go
+++ b/discovery_test.go
@@ -20,6 +20,7 @@ func TestDiscoverInWithMaxDepth(t *testing.T) {
 				"echoargs",
 				"env",
 				"exit",
+				"go",
 				"hello",
 				"suggest",
 			},
@@ -30,6 +31,9 @@ func TestDiscoverInWithMaxDepth(t *testing.T) {
 				"echoargs",
 				"env",
 				"exit",
+				"go",
+				"go build",
+				"go mod",
 				"hello",
 				"nested-1",
 				"nested-1 hello",
@@ -44,6 +48,11 @@ func TestDiscoverInWithMaxDepth(t *testing.T) {
 				"echoargs",
 				"env",
 				"exit",
+				"go",
+				"go build",
+				"go mod",
+				"go mod init",
+				"go mod tidy",
 				"hello",
 				"nested-1",
 				"nested-1 hello",
@@ -60,6 +69,11 @@ func TestDiscoverInWithMaxDepth(t *testing.T) {
 				"echoargs",
 				"env",
 				"exit",
+				"go",
+				"go build",
+				"go mod",
+				"go mod init",
+				"go mod tidy",
 				"hello",
 				"nested-1",
 				"nested-1 hello",
@@ -94,6 +108,55 @@ func TestDiscovererBuildsCommand(t *testing.T) {
 	var parent Module = &builtinModule{}
 	d := discoverer{onError: nil, modulefile: ".exoskeleton", maxDepth: 2}
 
+	cmdGo := &executableModule{
+		executableCommand: executableCommand{
+			parent:       parent,
+			name:         "go",
+			path:         filepath.Join(fixtures, "go.exoskeleton"),
+			discoveredIn: fixtures,
+			summary:      "Provides several commands",
+		},
+	}
+	cmdGoMod := &executableModule{
+		executableCommand: executableCommand{
+			parent:       cmdGo,
+			name:         "mod",
+			path:         filepath.Join(fixtures, "go.exoskeleton"),
+			args:         []string{"mod"},
+			discoveredIn: fixtures,
+			summary:      "module maintenance",
+		},
+	}
+	cmdGo.cmds = Commands{
+		&executableCommand{
+			parent:       cmdGo,
+			name:         "build",
+			path:         filepath.Join(fixtures, "go.exoskeleton"),
+			args:         []string{"build"},
+			summary:      "compile packages and dependencies",
+			discoveredIn: fixtures,
+		},
+		cmdGoMod,
+	}
+	cmdGoMod.cmds = Commands{
+		&executableCommand{
+			parent:       cmdGoMod,
+			name:         "init",
+			path:         filepath.Join(fixtures, "go.exoskeleton"),
+			args:         []string{"mod", "init"},
+			summary:      "initialize new module in current directory",
+			discoveredIn: fixtures,
+		},
+		&executableCommand{
+			parent:       cmdGoMod,
+			name:         "tidy",
+			path:         filepath.Join(fixtures, "go.exoskeleton"),
+			args:         []string{"mod", "tidy"},
+			summary:      "add missing and remove unused modules",
+			discoveredIn: fixtures,
+		},
+	}
+
 	scenarios := []struct {
 		executable string
 		expected   Command
@@ -123,6 +186,10 @@ func TestDiscovererBuildsCommand(t *testing.T) {
 					modulefile: d.modulefile,
 				},
 			},
+		},
+		{
+			"go.exoskeleton",
+			cmdGo,
 		},
 	}
 

--- a/executable_command.go
+++ b/executable_command.go
@@ -18,6 +18,8 @@ type executableCommand struct {
 	parent       Module
 	path         string
 	name         string
+	args         []string
+	summary      string
 	discoveredIn string
 }
 
@@ -28,7 +30,7 @@ func (cmd *executableCommand) DiscoveredIn() string { return cmd.discoveredIn }
 
 // Command returns an exec.Cmd that will run the executable with the given arguments.
 func (cmd *executableCommand) Command(args ...string) *exec.Cmd {
-	return exec.Command(cmd.path, args...)
+	return exec.Command(cmd.path, append(cmd.args, args...)...)
 }
 
 // Exec invokes the executable with the given arguments and environment.
@@ -77,6 +79,10 @@ func (cmd *executableCommand) Complete(_ *Entrypoint, args, env []string) ([]str
 // The executable is expected to write the summary to standard output and exit
 // successfully.
 func (cmd *executableCommand) Summary() (string, error) {
+	if cmd.summary != "" {
+		return cmd.summary, nil
+	}
+
 	return getMessageFromCommand(cmd, "summary")
 }
 

--- a/executable_command_test.go
+++ b/executable_command_test.go
@@ -26,3 +26,19 @@ func TestGetMessageFromExecutionTrimsLineBreaks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "out", summary)
 }
+
+func TestGetMessageFromExecutionWithoutArgs(t *testing.T) {
+	cmd := &executableCommand{path: filepath.Join(fixtures, "echoargs")}
+	output, err := cmd.getMessageFromExecution("summary")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "--summary", output)
+}
+
+func TestGetMessageFromExecutionWithArgs(t *testing.T) {
+	cmd := &executableCommand{path: filepath.Join(fixtures, "echoargs"), args: []string{"a", "b"}}
+	output, err := cmd.getMessageFromExecution("summary")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "a\nb\n--summary", output)
+}

--- a/executable_module.go
+++ b/executable_module.go
@@ -1,0 +1,20 @@
+package exoskeleton
+
+import (
+	"github.com/square/exoskeleton/pkg/shellcomp"
+)
+
+type executableModule struct {
+	executableCommand
+	cmds Commands
+}
+
+func (m *executableModule) Exec(e *Entrypoint, args, env []string) error {
+	return e.printModuleHelp(m, args)
+}
+
+func (m *executableModule) Complete(_ *Entrypoint, args, _ []string) ([]string, shellcomp.Directive, error) {
+	return m.Subcommands().completionsFor(args)
+}
+
+func (m *executableModule) Subcommands() Commands { return m.cmds }

--- a/fixtures/go.exoskeleton
+++ b/fixtures/go.exoskeleton
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "--describe-commands" ]]; then
+  cat << EOF
+{
+  "name": "go",
+  "summary": "Provides several commands",
+  "commands": [
+    {
+      "name": "build",
+      "summary": "compile packages and dependencies"
+    },
+    {
+      "name": "mod",
+      "summary": "module maintenance",
+      "commands": [
+        {
+          "name": "init",
+          "summary": "initialize new module in current directory"
+        },
+        {
+          "name": "tidy",
+          "summary": "add missing and remove unused modules"
+        }
+      ]
+    }
+  ]
+}
+EOF
+  exit 0
+fi
+
+echo "For testing --describe-commands"
+exit 80

--- a/menu_test.go
+++ b/menu_test.go
@@ -46,6 +46,7 @@ func TestBuildMenuSectionsUncached(t *testing.T) {
    echoargs  Echoes the args it received
    env       Prints environment variables
    exit      Exits with the given code
+   go:       Provides several commands
    hello     Prints "hello"
    suggest   Suggests arguments`,
 		nocolor(entrypoint.buildMenu(entrypoint.cmds, entrypoint).Sections.String()))
@@ -65,7 +66,7 @@ func TestBuildMenuSectionsReadFromCache(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(f.Name())
-	f.Write([]byte(fmt.Sprintf(`{"summary":{"%s/echoargs":{"modTime":%d,"value":"CACHED SUMMARY"}}}`, fixtures, modTime)))
+	f.Write([]byte(fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"CACHED SUMMARY"}}}`, modTime)))
 	entrypoint.cachePath = f.Name()
 
 	assert.Equal(t,
@@ -87,7 +88,7 @@ func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(f.Name())
-	f.Write([]byte(fmt.Sprintf(`{"summary":{"%s/echoargs":{"modTime":%d,"value":"STALE SUMMARY"}}}`, fixtures, modTime-1)))
+	f.Write([]byte(fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"STALE SUMMARY"}}}`, modTime-1)))
 	entrypoint.cachePath = f.Name()
 
 	assert.Equal(t,
@@ -98,7 +99,7 @@ func TestBuildMenuSectionsWriteToCacheWhenStale(t *testing.T) {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(f)
 
-	assert.Equal(t, fmt.Sprintf(`{"summary":{"%s/echoargs":{"modTime":%d,"value":"Echoes the args it received"}}}`, fixtures, modTime), buf.String())
+	assert.Equal(t, fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"Echoes the args it received"}}}`, modTime), buf.String())
 }
 
 func TestBuildMenuSectionsWriteToCacheWhenMissing(t *testing.T) {
@@ -126,7 +127,7 @@ func TestBuildMenuSectionsWriteToCacheWhenMissing(t *testing.T) {
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(f)
 
-	assert.Equal(t, fmt.Sprintf(`{"summary":{"%s/echoargs":{"modTime":%d,"value":"Echoes the args it received"}}}`, fixtures, modTime), buf.String())
+	assert.Equal(t, fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"Echoes the args it received"}}}`, modTime), buf.String())
 }
 
 // TODO: support NOCOLOR and remove this

--- a/summary_cache.go
+++ b/summary_cache.go
@@ -59,10 +59,12 @@ func (c *summaryCache) Read(cmd Command) (string, error) {
 		c.load()
 	}
 
+	cacheKey := Usage(cmd)
+
 	modTime, err := modTime(cmd)
 	if err != nil {
 		c.onError(CacheError{Cause: err, Message: "skipping cache for " + cmd.Path()})
-	} else if item, ok := c.data.Summary[cmd.Path()]; ok && item.ModTime == modTime {
+	} else if item, ok := c.data.Summary[cacheKey]; ok && item.ModTime == modTime {
 		return item.Value, nil
 	}
 
@@ -71,7 +73,7 @@ func (c *summaryCache) Read(cmd Command) (string, error) {
 		if c.data.Summary == nil {
 			c.data.Summary = make(map[string]cachedValue)
 		}
-		c.data.Summary[cmd.Path()] = cachedValue{ModTime: modTime, Value: summary}
+		c.data.Summary[cacheKey] = cachedValue{ModTime: modTime, Value: summary}
 		c.dump()
 	}
 	return summary, err


### PR DESCRIPTION
- [x] Using `cmd.Path()` as the cache key in `summaryCache` does not work