### PR TITLE
fix: Evaluate `--describe-commands` lazily

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -1,7 +1,6 @@
 package exoskeleton
 
 import (
-	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -103,12 +102,15 @@ func (d *discoverer) buildCommand(discoveredIn string, parent Module, file fs.Di
 
 		// if the executable has the extension ".exoskeleton" then we should treat it as a module.
 		if filepath.Ext(name) == executableModuleExtension && (d.maxDepth == -1 || d.depth < d.maxDepth) {
-			// Execute this command with the `--describe-commands` flag to get the subcommands
-			if module, err := d.discoverSubcommands(executable); err != nil {
-				return nil, DiscoveryError{Cause: err, Path: path}
-			} else {
-				return module, nil
-			}
+			return &executableModule{
+				executableCommand: *executable,
+				discoverer: discoverer{
+					maxDepth:   d.maxDepth,
+					depth:      d.depth + 1,
+					onError:    d.onError,
+					modulefile: d.modulefile,
+				},
+			}, nil
 		}
 
 		return executable, nil
@@ -119,53 +121,6 @@ type commandDescriptor struct {
 	Name     string               `json:"name"`
 	Summary  string               `json:"summary"`
 	Commands []*commandDescriptor `json:"commands,omitempty"`
-}
-
-// discoverSubcommands invokes an executable with `--describe-commands` and constructs
-// a tree of modules and subcommands (all to be invoked through the given executable)
-// from the JSON output.
-func (d *discoverer) discoverSubcommands(executable *executableCommand) (Command, error) {
-	cmd := executable.Command("--describe-commands")
-	cmd.Stderr = nil
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-
-	var descriptor *commandDescriptor
-	if err := json.Unmarshal(output, &descriptor); err != nil {
-		return nil, err
-	}
-
-	executable.name = descriptor.Name
-	executable.summary = descriptor.Summary
-	m := &executableModule{executableCommand: *executable}
-	m.cmds = d.toCommands(m, descriptor.Commands, nil)
-	return m, nil
-}
-
-func (d *discoverer) toCommands(parent *executableModule, descriptors []*commandDescriptor, args []string) Commands {
-	var cmds Commands
-	for _, descriptor := range descriptors {
-		c := &executableCommand{
-			parent:       parent,
-			discoveredIn: parent.discoveredIn,
-			path:         parent.path,
-			args:         append(args, descriptor.Name),
-			name:         descriptor.Name,
-			summary:      descriptor.Summary,
-		}
-
-		depth := d.depth + len(args) + 1
-		if len(descriptor.Commands) > 0 && (d.maxDepth == -1 || depth < d.maxDepth) {
-			m := &executableModule{executableCommand: *c}
-			m.cmds = d.toCommands(m, descriptor.Commands, append(args, m.name))
-			cmds = append(cmds, m)
-		} else {
-			cmds = append(cmds, c)
-		}
-	}
-	return cmds
 }
 
 func followSymlinks(path string) (fs.DirEntry, error) {

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -114,55 +114,6 @@ func TestDiscovererBuildsCommand(t *testing.T) {
 	var parent Module = &builtinModule{}
 	d := discoverer{onError: nil, modulefile: ".exoskeleton", maxDepth: 2}
 
-	cmdGo := &executableModule{
-		executableCommand: executableCommand{
-			parent:       parent,
-			name:         "go",
-			path:         filepath.Join(fixtures, "go.exoskeleton"),
-			discoveredIn: fixtures,
-			summary:      "Provides several commands",
-		},
-	}
-	cmdGoMod := &executableModule{
-		executableCommand: executableCommand{
-			parent:       cmdGo,
-			name:         "mod",
-			path:         filepath.Join(fixtures, "go.exoskeleton"),
-			args:         []string{"mod"},
-			discoveredIn: fixtures,
-			summary:      "module maintenance",
-		},
-	}
-	cmdGo.cmds = Commands{
-		&executableCommand{
-			parent:       cmdGo,
-			name:         "build",
-			path:         filepath.Join(fixtures, "go.exoskeleton"),
-			args:         []string{"build"},
-			summary:      "compile packages and dependencies",
-			discoveredIn: fixtures,
-		},
-		cmdGoMod,
-	}
-	cmdGoMod.cmds = Commands{
-		&executableCommand{
-			parent:       cmdGoMod,
-			name:         "init",
-			path:         filepath.Join(fixtures, "go.exoskeleton"),
-			args:         []string{"mod", "init"},
-			summary:      "initialize new module in current directory",
-			discoveredIn: fixtures,
-		},
-		&executableCommand{
-			parent:       cmdGoMod,
-			name:         "tidy",
-			path:         filepath.Join(fixtures, "go.exoskeleton"),
-			args:         []string{"mod", "tidy"},
-			summary:      "add missing and remove unused modules",
-			discoveredIn: fixtures,
-		},
-	}
-
 	scenarios := []struct {
 		executable string
 		expected   Command
@@ -195,7 +146,20 @@ func TestDiscovererBuildsCommand(t *testing.T) {
 		},
 		{
 			"go.exoskeleton",
-			cmdGo,
+			&executableModule{
+				executableCommand: executableCommand{
+					parent:       parent,
+					name:         "go",
+					path:         filepath.Join(fixtures, "go.exoskeleton"),
+					discoveredIn: fixtures,
+				},
+				discoverer: discoverer{
+					maxDepth:   d.maxDepth,
+					depth:      d.depth + 1,
+					onError:    d.onError,
+					modulefile: d.modulefile,
+				},
+			},
 		},
 	}
 

--- a/executable_module.go
+++ b/executable_module.go
@@ -1,12 +1,23 @@
 package exoskeleton
 
 import (
+	"encoding/json"
+
 	"github.com/square/exoskeleton/pkg/shellcomp"
 )
 
 type executableModule struct {
 	executableCommand
-	cmds Commands
+	cmds       Commands
+	discoverer discoverer
+}
+
+func (m *executableModule) Summary() (string, error) {
+	if m.cmds == nil {
+		m.discover()
+	}
+
+	return m.summary, nil
 }
 
 func (m *executableModule) Exec(e *Entrypoint, args, env []string) error {
@@ -17,4 +28,57 @@ func (m *executableModule) Complete(_ *Entrypoint, args, _ []string) ([]string, 
 	return m.Subcommands().completionsFor(args)
 }
 
-func (m *executableModule) Subcommands() Commands { return m.cmds }
+func (m *executableModule) Subcommands() Commands {
+	if m.cmds == nil {
+		m.discover()
+	}
+
+	return m.cmds
+}
+
+// discover invokes an executable with `--describe-commands` and constructs a tree
+// of modules and subcommands (all to be invoked through the given executable)
+// from the JSON output.
+func (m *executableModule) discover() {
+	cmd := m.Command("--describe-commands")
+	cmd.Stderr = nil
+	output, err := cmd.Output()
+	if err != nil {
+		m.discoverer.onError(DiscoveryError{Cause: err, Path: m.path})
+		return
+	}
+
+	var descriptor *commandDescriptor
+	if err := json.Unmarshal(output, &descriptor); err != nil {
+		m.discoverer.onError(DiscoveryError{Cause: err, Path: m.path})
+		return
+	}
+
+	m.name = descriptor.Name
+	m.summary = descriptor.Summary
+	m.cmds = m.discoverer.toCommands(m, descriptor.Commands, nil)
+}
+
+func (d *discoverer) toCommands(parent *executableModule, descriptors []*commandDescriptor, args []string) Commands {
+	cmds := Commands{}
+	for _, descriptor := range descriptors {
+		c := &executableCommand{
+			parent:       parent,
+			discoveredIn: parent.discoveredIn,
+			path:         parent.path,
+			args:         append(args, descriptor.Name),
+			name:         descriptor.Name,
+			summary:      descriptor.Summary,
+		}
+
+		depth := d.depth + len(args)
+		if len(descriptor.Commands) > 0 && (d.maxDepth == -1 || depth < d.maxDepth) {
+			m := &executableModule{executableCommand: *c}
+			m.cmds = d.toCommands(m, descriptor.Commands, append(args, m.name))
+			cmds = append(cmds, m)
+		} else {
+			cmds = append(cmds, c)
+		}
+	}
+	return cmds
+}


### PR DESCRIPTION
This allows an executable module to be discovered even if it is faulty