### PR TITLE
fix: Do not normalize `--help` or `-h` when they don't immediately follow an identifiable command

### DIFF
--- a/contract.go
+++ b/contract.go
@@ -79,15 +79,8 @@ func readSummaryFromExecutable(cmd *executableCommand) (string, error) {
 	return summary, nil
 }
 
-func readHelpFromExecutable(cmd *executableCommand, args []string) (string, error) {
-	var help string
-	var err error
-
-	if len(args) == 0 {
-		help, err = getMessageFromCommand(cmd, "help")
-	} else {
-		help, err = getMessageFromExecution(cmd, args, "help")
-	}
+func readHelpFromExecutable(cmd *executableCommand) (string, error) {
+	help, err := getMessageFromCommand(cmd, "help")
 
 	if err != nil {
 		return "",
@@ -187,12 +180,12 @@ func getMessageFromCommand(cmd *executableCommand, message string) (string, erro
 	case script:
 		s, err := getMessageFromMagicComments(f, message)
 		if s == "" {
-			return getMessageFromExecution(cmd, nil, message)
+			return getMessageFromExecution(cmd, message)
 		} else {
 			return s, err
 		}
 	case binary:
-		return getMessageFromExecution(cmd, nil, message)
+		return getMessageFromExecution(cmd, message)
 	default:
 		return "", fmt.Errorf("Invalid value for t: %v", t)
 	}
@@ -267,8 +260,8 @@ func getHelpFromMagicComments(reader *bufio.Reader) (string, error) {
 	}
 }
 
-func getMessageFromExecution(c *executableCommand, args []string, message string) (string, error) {
-	cmd := c.Command(append(args, "--"+message)...)
+func getMessageFromExecution(c *executableCommand, message string) (string, error) {
+	cmd := c.Command("--" + message)
 	cmd.Stderr = nil
 	out, err := cmd.Output()
 	if err != nil {

--- a/contract_test.go
+++ b/contract_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGetMessageFromExecutionHandlesErrors(t *testing.T) {
 	cmd := &executableCommand{path: filepath.Join(fixtures, "edge-cases", "summary-fail")}
-	summary, err := getMessageFromExecution(cmd, nil, "summary")
+	summary, err := getMessageFromExecution(cmd, "summary")
 
 	var ee *exec.ExitError
 
@@ -21,7 +21,7 @@ func TestGetMessageFromExecutionHandlesErrors(t *testing.T) {
 
 func TestGetMessageFromExecutionTrimsLineBreaks(t *testing.T) {
 	cmd := &executableCommand{path: filepath.Join(fixtures, "edge-cases", "summary-with-newlines")}
-	summary, err := getMessageFromExecution(cmd, nil, "summary")
+	summary, err := getMessageFromExecution(cmd, "summary")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "out", summary)
@@ -29,7 +29,7 @@ func TestGetMessageFromExecutionTrimsLineBreaks(t *testing.T) {
 
 func TestGetMessageFromExecutionWithoutArgs(t *testing.T) {
 	cmd := &executableCommand{path: filepath.Join(fixtures, "echoargs")}
-	output, err := getMessageFromExecution(cmd, nil, "summary")
+	output, err := getMessageFromExecution(cmd, "summary")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "--summary", output)
@@ -37,7 +37,7 @@ func TestGetMessageFromExecutionWithoutArgs(t *testing.T) {
 
 func TestGetMessageFromExecutionWithArgs(t *testing.T) {
 	cmd := &executableCommand{path: filepath.Join(fixtures, "echoargs"), args: []string{"a", "b"}}
-	output, err := getMessageFromExecution(cmd, nil, "summary")
+	output, err := getMessageFromExecution(cmd, "summary")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "a\nb\n--summary", output)

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -128,7 +128,7 @@ func (e *Entrypoint) onError(err error) {
 	}
 }
 
-func (e *Entrypoint) commandNotFound(cmd nullCommand) {
+func (e *Entrypoint) commandNotFound(cmd Command) {
 	for _, callback := range e.commandNotFoundCallbacks {
 		callback(e, cmd)
 	}

--- a/executable_command.go
+++ b/executable_command.go
@@ -91,20 +91,5 @@ func (cmd *executableCommand) Summary() (string, error) {
 // The executable is expected to write the help text to standard output and exit
 // successfully.
 func (cmd *executableCommand) Help() (string, error) {
-	return cmd.helpWithArgs(nil)
-}
-
-// helpWithArgs returns the help text for the command, passing
-// any arguments through to the executable that responds to --help.
-func (cmd *executableCommand) helpWithArgs(args []string) (string, error) {
-	return readHelpFromExecutable(cmd, args)
-}
-
-// helpWithArgsProvider can be implemented by commands to
-// provide HelpWithArgs, to accept command line arguments
-// when printing help.
-//
-// It is not exported yet because its API isn't stable.
-type helpWithArgsProvider interface {
-	helpWithArgs([]string) (string, error)
+	return readHelpFromExecutable(cmd)
 }

--- a/help_cmd.go
+++ b/help_cmd.go
@@ -38,8 +38,6 @@ func HelpExec(e *Entrypoint, args, _ []string) error {
 func (e *Entrypoint) helpFor(cmd Command, args []string) (string, error) {
 	if m, ok := cmd.(Module); ok {
 		return e.buildModuleHelp(m, args)
-	} else if p, ok := cmd.(helpWithArgsProvider); ok {
-		return p.helpWithArgs(args)
 	} else {
 		return cmd.Help()
 	}

--- a/help_cmd_test.go
+++ b/help_cmd_test.go
@@ -24,12 +24,3 @@ func TestHelpForWithExecution(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "USAGE: help from execution", help)
 }
-
-func TestHelpForWithExecutionPassesArgsThrough(t *testing.T) {
-	cmd := &executableCommand{path: filepath.Join(fixtures, "echoargs"), args: []string{"a"}}
-	entrypoint := &Entrypoint{cmds: Commands{cmd}}
-	help, err := entrypoint.helpFor(cmd, []string{"b"})
-
-	assert.NoError(t, err)
-	assert.Equal(t, "a\nb\n--help", help)
-}

--- a/identification.go
+++ b/identification.go
@@ -17,8 +17,8 @@ import "strings"
 func (e *Entrypoint) Identify(rawArgs []string) (Command, []string, error) {
 	cmd, args, err := identify(e, normalizeArgs(rawArgs))
 
-	if n, ok := cmd.(nullCommand); ok {
-		e.commandNotFound(n)
+	if IsNull(cmd) {
+		e.commandNotFound(cmd)
 	}
 
 	return cmd, args, err

--- a/identification_test.go
+++ b/identification_test.go
@@ -69,19 +69,26 @@ func TestIdentify(t *testing.T) {
 
 		// Normalizes `CMD --help` to `help CMD`
 		{[]string{"--help"}, help, []string{}},
+		{[]string{"--help", "--flag"}, help, []string{"--flag"}},
 		{[]string{"a", "--help"}, help, []string{"a"}},
 		{[]string{"b", "c", "--help"}, help, []string{"b", "c"}},
-		{[]string{"b:c", "--help"}, help, []string{"b:c"}},
+		{[]string{"b:c", "--help"}, help, []string{"b", "c"}},
 
 		// Normalizes `CMD -h` to `help CMD`
 		{[]string{"-h"}, help, []string{}},
+		{[]string{"-h", "--flag"}, help, []string{"--flag"}},
 		{[]string{"a", "-h"}, help, []string{"a"}},
 		{[]string{"b", "c", "-h"}, help, []string{"b", "c"}},
-		{[]string{"b:c", "-h"}, help, []string{"b:c"}},
+		{[]string{"b:c", "-h"}, help, []string{"b", "c"}},
 
 		// Does not normalize `--help`/`-h` after `--`
 		{[]string{"a", "--", "--help"}, a, []string{"--", "--help"}},
 		{[]string{"a", "--", "-h"}, a, []string{"--", "-h"}},
+
+		// Does not normalize `CMD <arg> -h` to `help CMD <arg>`
+		{[]string{"x", "-h"}, nullCommand{entrypoint, "x"}, []string{"-h"}},
+		{[]string{"a", "arg", "-h"}, a, []string{"arg", "-h"}},
+		{[]string{"b", "c", "arg", "-h"}, c, []string{"arg", "-h"}},
 	}
 
 	for _, s := range scenarios {

--- a/usage.go
+++ b/usage.go
@@ -12,9 +12,13 @@ func Usage(cmd Command) string {
 // For example, given the Tidy command in the Go CLI ('go mod tidy'), UsageRelativeTo(Tidy, Mod)
 // would be 'tidy' and UsageRelativeTo(Tidy, Go) would be 'mod tidy'.
 func UsageRelativeTo(cmd Command, m Module) string {
-	var usage []string
+	return strings.Join(argsRelativeTo(cmd, m), " ")
+}
+
+func argsRelativeTo(cmd Command, m Module) []string {
+	args := []string{}
 	for parent := cmd; parent != nil && parent != m; parent = parent.Parent() {
-		usage = append([]string{parent.Name()}, usage...)
+		args = append([]string{parent.Name()}, args...)
 	}
-	return strings.Join(usage, " ")
+	return args
 }


### PR DESCRIPTION
**This is an alternative implementation to https://github.com/square/exoskeleton/pull/13** that simplifies the API in preparation for https://github.com/square/exoskeleton/pull/27

If the `go` CLI were an exoskeleton and `go mod` could describe itself but not its subcommands, then `go --all` would list `go mod` in its menu but not `go mod tidy` (it wouldn't know about `tidy`).

### [BEFORE] User Experience

When you run `go mod tidy --help`,
1. `go` rewrites `go mod tidy --help` to `go help mod tidy`
2. `go help` executes `mod` with the args `{"tidy", "--help"}` ✅ 

When you run `go help mod tidy`,
1. `go help` executes `mod` with the args `{"tidy", "--help"}`

### [AFTER] User Experience

When you run `go mod tidy --help`,
1. `go` **does not rewrite** `go mod tidy --help`
2. It executes `mod` with the args `{"tidy", "--help"}` ✅ 

When you run `go help mod tidy`,
1. `go help` executes `mod` with the args `{"--help"}`
   - **NOTE:** The output would be surprising — it would be the help output for `mod`. You might be expecting the help output for `tidy`, but `go` doesn't know about `tidy`. What `go help` should probably do is to give a usage error — that the argument `tidy` is unexpected. (See #28)