### PR TITLE
feat: Render menus using Go templates and allow clients to supply their own

### DIFF
--- a/entrypoint.go
+++ b/entrypoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/square/exoskeleton/pkg/shellcomp"
 )
@@ -30,6 +31,7 @@ type Entrypoint struct {
 	maxDepth                 int
 	cachePath                string
 	menuHeadingFor           MenuHeadingForFunc
+	menuTemplate             *template.Template
 	moduleMetadataFilename   string
 	errorCallbacks           []ErrorFunc
 	commandNotFoundCallbacks []CommandNotFoundFunc

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -115,7 +115,6 @@ func newWithDefaults(path string) *Entrypoint {
 		name:                   name,
 		maxDepth:               -1,
 		cachePath:              cachePath,
-		menuHeadingFor:         func(_ Module, _ Command) string { return "COMMANDS" },
 		moduleMetadataFilename: ".exoskeleton",
 		cmdsToPrepend:          []Command{},
 		cmdsToAppend:           []Command{},

--- a/fixtures/nested-1/hello
+++ b/fixtures/nested-1/hello
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
-# SUMMARY: Prints "hello"
+
+# Don't include in menu_test.go
+if [ "$1" = "--summary" ]; then exit 0; fi
 
 printf "hello"

--- a/fixtures/nested-1/nested-2/hello
+++ b/fixtures/nested-1/nested-2/hello
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
-# SUMMARY: Prints "hello"
+
+# Don't include in menu_test.go
+if [ "$1" = "--summary" ]; then exit 0; fi
 
 printf "hello"

--- a/fixtures/nested-1/nested-2/nested-3/hello
+++ b/fixtures/nested-1/nested-2/nested-3/hello
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
-# SUMMARY: Prints "hello"
+
+# Don't include in menu_test.go
+if [ "$1" = "--summary" ]; then exit 0; fi
 
 printf "hello"

--- a/fixtures/nested-1/nested-2/nested-3/nested-4/hello
+++ b/fixtures/nested-1/nested-2/nested-3/nested-4/hello
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
-# SUMMARY: Prints "hello"
+
+# Don't include in menu_test.go
+if [ "$1" = "--summary" ]; then exit 0; fi
 
 printf "hello"

--- a/help_cmd.go
+++ b/help_cmd.go
@@ -56,7 +56,7 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 	}
 
 	cache := &summaryCache{Path: e.cachePath, onError: e.onError}
-	opts := &menuOptions{
+	opts := &MenuOptions{
 		HeadingFor: e.menuHeadingFor,
 		SummaryFor: cache.Read,
 		Template:   e.menuTemplate,
@@ -70,7 +70,7 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 		}
 	}
 
-	menu, errs := menuFor(m, opts)
+	menu, errs := MenuFor(m, opts)
 	for _, err := range errs {
 		e.onError(err)
 	}

--- a/help_cmd.go
+++ b/help_cmd.go
@@ -73,7 +73,13 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 		cmds = e.expandModules(cmds)
 	}
 
-	menu, errs := e.buildMenu(cmds, m)
+	cache := &summaryCache{Path: e.cachePath, onError: e.onError}
+	opts := &buildMenuOptions{
+		HeadingFor: e.menuHeadingFor,
+		SummaryFor: cache.Read,
+	}
+
+	menu, errs := buildMenu(cmds, m, opts)
 	for _, err := range errs {
 		e.onError(err)
 	}

--- a/help_cmd.go
+++ b/help_cmd.go
@@ -56,9 +56,10 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 	}
 
 	cache := &summaryCache{Path: e.cachePath, onError: e.onError}
-	opts := &buildMenuOptions{
+	opts := &menuOptions{
 		HeadingFor: e.menuHeadingFor,
 		SummaryFor: cache.Read,
+		Template:   e.menuTemplate,
 	}
 
 	for _, arg := range args {
@@ -69,11 +70,11 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 		}
 	}
 
-	menu, errs := buildMenu(m, opts)
+	menu, errs := menuFor(m, opts)
 	for _, err := range errs {
 		e.onError(err)
 	}
-	return menu.String(), nil
+	return menu, nil
 }
 
 func printHelp(help string) {

--- a/help_cmd.go
+++ b/help_cmd.go
@@ -73,7 +73,11 @@ func (e *Entrypoint) buildModuleHelp(m Module, args []string) (string, error) {
 		cmds = e.expandModules(cmds)
 	}
 
-	return e.buildMenu(cmds, m).String(), nil
+	menu, errs := e.buildMenu(cmds, m)
+	for _, err := range errs {
+		e.onError(err)
+	}
+	return menu.String(), nil
 }
 
 func (e *Entrypoint) expandModules(cmds Commands) Commands {

--- a/menu.go
+++ b/menu.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 )
 
-func (e *Entrypoint) buildMenu(c Commands, m Module) menu {
+func (e *Entrypoint) buildMenu(c Commands, m Module) (menu, []error) {
 	usage := Usage(m) + " <command> [<args>]"
 
 	var items menuItems
+	var errs []error
 
 	seen := make(map[string]bool)
 	cache := &summaryCache{Path: e.cachePath, onError: e.onError}
@@ -28,7 +29,7 @@ func (e *Entrypoint) buildMenu(c Commands, m Module) menu {
 		}
 
 		if summary, err := cache.Read(cmd); err != nil {
-			e.onError(err)
+			errs = append(errs, err)
 		} else if summary != "" {
 			heading := e.menuHeadingFor(m, cmd)
 			items = append(items, &menuItem{Name: name, Summary: summary, Heading: heading})
@@ -62,7 +63,7 @@ func (e *Entrypoint) buildMenu(c Commands, m Module) menu {
 		strings.TrimLeft(UsageRelativeTo(m, e)+" <command>", " "),
 	)
 
-	return menu{Usage: usage, Sections: sections, Trailer: trailer}
+	return menu{Usage: usage, Sections: sections, Trailer: trailer}, errs
 }
 
 type menu struct {

--- a/menu.go
+++ b/menu.go
@@ -28,11 +28,27 @@ var templateFuncs = template.FuncMap{
 // SummaryFunc is a function that is expected to return the heading
 type SummaryFunc func(Command) (string, error)
 
-type menuOptions struct {
-	Depth      int
+// MenuOptions are the options that control how menus are constructed for modules.
+type MenuOptions struct {
+	// Depth describes how recursively a menu should be constructed. Its default
+	// value is 0, which indicates that the menu should list only the commands
+	// that are descendants of the module. A value of 1 would list descendants one
+	// level deep, a value of 2 would list descendants two levels deep, etc. A value
+	// -1 lists all descendants.
+	Depth int
+
+	// HeadingFor accepts a Command the Module the menu is being prepared for
+	// and returns a string to use as a section heading for the Command.
+	// The default function returns "COMMANDS".
 	HeadingFor MenuHeadingForFunc
+
+	// SummaryFor accepts a Command and returns its summary and, optionally, an error.
+	// The default function invokes Summary() on the provided Command.
 	SummaryFor SummaryFunc
-	Template   *template.Template
+
+	// Template is executed with the constructed exoskeleton.Menu to render
+	// help content for a Module.
+	Template *template.Template
 }
 
 // Menu is the data passed to MenuOptions.Template when it is executed.
@@ -73,8 +89,8 @@ type MenuItem struct {
 	Width   int
 }
 
-// menuFor renders a menu of commands for a Module.
-func menuFor(m Module, opts *menuOptions) (string, []error) {
+// MenuFor renders a menu of commands for a Module.
+func MenuFor(m Module, opts *MenuOptions) (string, []error) {
 	if opts.Template == nil {
 		opts.Template = template.Must(template.New("menu").Funcs(templateFuncs).Parse(menuTemplate))
 	}
@@ -88,7 +104,7 @@ func menuFor(m Module, opts *menuOptions) (string, []error) {
 }
 
 // buildMenu constructs a Menu of Commands with their short summary strings for a given Module.
-func buildMenu(m Module, opts *menuOptions) (*Menu, []error) {
+func buildMenu(m Module, opts *MenuOptions) (*Menu, []error) {
 	if opts.SummaryFor == nil {
 		opts.SummaryFor = func(cmd Command) (string, error) { return cmd.Summary() }
 	}

--- a/menu_test.go
+++ b/menu_test.go
@@ -17,10 +17,10 @@ func TestBuildMenuUsage(t *testing.T) {
 	module := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
-	menu, _ := buildMenu(entrypoint, &menuOptions{})
+	menu, _ := buildMenu(entrypoint, &MenuOptions{})
 	assert.Equal(t, "entrypoint <command> [<args>]", menu.Usage)
 
-	menu, _ = buildMenu(module, &menuOptions{})
+	menu, _ = buildMenu(module, &MenuOptions{})
 	assert.Equal(t, "entrypoint module <command> [<args>]", menu.Usage)
 }
 
@@ -29,10 +29,10 @@ func TestMenuForTrailer(t *testing.T) {
 	module := &directoryModule{executableCommand: executableCommand{parent: entrypoint, name: "module"}}
 	entrypoint.cmds = Commands{module}
 
-	menu, _ := menuFor(entrypoint, &menuOptions{})
+	menu, _ := MenuFor(entrypoint, &MenuOptions{})
 	assert.Contains(t, menu, "Run \033[96mentrypoint help <command>\033[0m to print information on a specific command.")
 
-	menu, _ = menuFor(module, &menuOptions{})
+	menu, _ = MenuFor(module, &MenuOptions{})
 	assert.Contains(t, menu, "Run \033[96mentrypoint help module <command>\033[0m to print information on a specific command.")
 }
 
@@ -95,7 +95,7 @@ func TestMenuForSectionsUncached(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		menu, errs := menuFor(entrypoint, &menuOptions{Depth: s.depth})
+		menu, errs := MenuFor(entrypoint, &MenuOptions{Depth: s.depth})
 		assert.Empty(t, errs)
 		assert.Equal(t, s.expected, sections(nocolor(menu)), "Given depth=%d", s.depth)
 	}
@@ -118,7 +118,7 @@ func TestMenuForSectionsReadFromCache(t *testing.T) {
 	f.Write([]byte(fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"CACHED SUMMARY"}}}`, modTime)))
 	cache := &summaryCache{Path: f.Name(), onError: entrypoint.onError}
 
-	menu, errs := menuFor(entrypoint, &menuOptions{SummaryFor: cache.Read})
+	menu, errs := MenuFor(entrypoint, &MenuOptions{SummaryFor: cache.Read})
 	assert.Empty(t, errs)
 	assert.Equal(t, "COMMANDS\n   echoargs  CACHED SUMMARY", sections(nocolor(menu)))
 }
@@ -140,7 +140,7 @@ func TestMenuForSectionsWriteToCacheWhenStale(t *testing.T) {
 	f.Write([]byte(fmt.Sprintf(`{"summary":{"entrypoint echoargs":{"modTime":%d,"value":"STALE SUMMARY"}}}`, modTime-1)))
 	cache := &summaryCache{Path: f.Name(), onError: entrypoint.onError}
 
-	menu, errs := menuFor(entrypoint, &menuOptions{SummaryFor: cache.Read})
+	menu, errs := MenuFor(entrypoint, &MenuOptions{SummaryFor: cache.Read})
 	assert.Empty(t, errs)
 	assert.Equal(t, "COMMANDS\n   echoargs  Echoes the args it received", sections(nocolor(menu)))
 
@@ -168,7 +168,7 @@ func TestMenuForSectionsWriteToCacheWhenMissing(t *testing.T) {
 	f.Write([]byte(`{"summary":{}`))
 	cache := &summaryCache{Path: f.Name(), onError: entrypoint.onError}
 
-	menu, errs := menuFor(entrypoint, &menuOptions{SummaryFor: cache.Read})
+	menu, errs := MenuFor(entrypoint, &MenuOptions{SummaryFor: cache.Read})
 	assert.Empty(t, errs)
 	assert.Equal(t, "COMMANDS\n   echoargs  Echoes the args it received", sections(nocolor(menu)))
 

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package exoskeleton
 
-import "github.com/square/exoskeleton/pkg/shellcomp"
+import (
+	"text/template"
+
+	"github.com/square/exoskeleton/pkg/shellcomp"
+)
 
 // An Option applies optional changes to an Exoskeleton Entrypoint.
 type Option interface {
@@ -113,6 +117,12 @@ func WithMaxDepth(value int) Option {
 // a Command should be listed under in the main menu.
 func WithMenuHeadingFor(fn MenuHeadingForFunc) Option {
 	return (optionFunc)(func(e *Entrypoint) { e.menuHeadingFor = fn })
+}
+
+// WithMenuTemplate sets the template that will be used to render help for modules.
+// The template will be executed with an instance of exoskeleton.Menu as its data.
+func WithMenuTemplate(value *template.Template) Option {
+	return (optionFunc)(func(e *Entrypoint) { e.menuTemplate = value })
 }
 
 // WithModuleMetadataFilename sets the filename to use for module metadata.


### PR DESCRIPTION
This PR allows exoskeleton applications to implement their own `help` command, with access to all the features of Exoskeleton's native `help` command.
