### PR TITLE
fix: Don't foreground subprocesses if they return ENOTTY

### DIFF
--- a/executable_command.go
+++ b/executable_command.go
@@ -1,6 +1,7 @@
 package exoskeleton
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"syscall"
@@ -45,7 +46,12 @@ func (cmd *executableCommand) Exec(_ *Entrypoint, args, env []string) error {
 		Foreground: true,
 	}
 
-	return command.Run()
+	err := command.Run()
+	if errors.Is(err, syscall.ENOTTY) {
+		command.SysProcAttr = nil
+		return command.Run()
+	}
+	return err
 }
 
 // Complete invokes the executable with `--complete` as its first argument


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/square/exoskeleton/pull/31

When running in a context without a controlling terminal (CTTY) such as CI, we were getting the error `fork/exec: inappropriate ioctl for device`

Contrast with https://github.com/square/exoskeleton/pull/32