### PR TITLE
chore(changelog): Update CHANGELOG.md with a PR instead of a commit

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: make CHANGELOG.md
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: "doc(changelog): Update CHANGELOG.md"
+          branch: cliffy/changelog
+          add-paths: CHANGELOG.md
+          commit-message: "doc(changelog): Update CHANGELOG.md"
+          title: "doc(changelog): Update CHANGELOG.md"
+          body: |
+            **[Preview](https://github.com/square/exoskeleton/blob/cliffy/changelog/CHANGELOG.md)**


### PR DESCRIPTION
Follow up on https://github.com/square/exoskeleton/pull/40

This'll create PRs for us to approve and merge — a little more manual but maybe an OK flow that we could further automate later if it's painful