### PR TITLE
refactor: Extract Contracts from discoverer and allow clients to supply their own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-
+      - uses: cashapp/activate-hermit@v1
       - name: Test
         run: |
           go test -v ./...

--- a/contract_directory.go
+++ b/contract_directory.go
@@ -1,0 +1,50 @@
+package exoskeleton
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// DirectoryContract handles directories containing a module metadata file.
+//
+// The module metadata filename is configured on the Entrypoint and passed through
+// the discoverer, not stored on the contract itself.
+type DirectoryContract struct {
+	MetadataFilename string
+}
+
+func (c *DirectoryContract) BuildCommand(path string, info fs.DirEntry, parent Module, d DiscoveryContext) (Command, error) {
+	// Only applies to directories
+	if !info.IsDir() {
+		return nil, ErrNotApplicable
+	}
+
+	modulefilePath := filepath.Join(path, c.MetadataFilename)
+
+	// If the directory doesn't contain the modulefile, it's just a regular directory
+	if !exists(modulefilePath) {
+		return nil, ErrNotApplicable
+	}
+
+	// Stop discovering modules if we've searched past maxDepth
+	if d.MaxDepth() == 0 {
+		return nil, nil // Ignore due to depth limit
+	}
+
+	return &directoryModule{
+		executableCommand: executableCommand{
+			parent:       parent,
+			path:         modulefilePath,
+			name:         filepath.Base(path),
+			discoveredIn: filepath.Dir(path),
+			executor:     d.Executor(),
+		},
+		discoverer: d.Next(),
+	}, nil
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || !os.IsNotExist(err)
+}

--- a/contract_executable.go
+++ b/contract_executable.go
@@ -1,0 +1,60 @@
+package exoskeleton
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+const executableModuleExtension = ".exoskeleton"
+
+// ExecutableContract handles executables that respond to --describe-commands.
+//
+// The extension is hardcoded to ".exoskeleton", and the --describe-commands flag is also hardcoded.
+type ExecutableContract struct {
+}
+
+func (c *ExecutableContract) BuildCommand(path string, info fs.DirEntry, parent Module, d DiscoveryContext) (Command, error) {
+	// Only applies to files
+	if info.IsDir() {
+		return nil, ErrNotApplicable
+	}
+
+	// Must have the configured extension
+	name := filepath.Base(path)
+	if filepath.Ext(name) != executableModuleExtension {
+		return nil, ErrNotApplicable
+	}
+
+	// Must be executable
+	if ok, err := isExecutable(info); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, ErrNotApplicable
+	}
+
+	commandName := strings.TrimSuffix(name, executableModuleExtension)
+
+	// Stop discovering modules if we've searched past maxDepth
+	// But still create a regular executableCommand (not a module)
+	if d.MaxDepth() == 0 {
+		return &executableCommand{
+			parent:       parent,
+			path:         path,
+			name:         commandName,
+			discoveredIn: filepath.Dir(path),
+			executor:     d.Executor(),
+		}, nil
+	}
+
+	return &executableModule{
+		executableCommand: executableCommand{
+			parent:       parent,
+			path:         path,
+			name:         commandName,
+			discoveredIn: filepath.Dir(path),
+			executor:     d.Executor(),
+		},
+		discoverer: d.Next(),
+	}, nil
+}

--- a/contract_shell_script.go
+++ b/contract_shell_script.go
@@ -1,0 +1,71 @@
+package exoskeleton
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ShellScriptContract handles shell scripts with magic comments.
+//
+// Scripts are detected by checking for a shebang (#!) at the start of the file.
+// They provide metadata via magic comments like "# SUMMARY:" and "# HELP:".
+type ShellScriptContract struct{}
+
+func (c *ShellScriptContract) BuildCommand(path string, info fs.DirEntry, parent Module, d DiscoveryContext) (Command, error) {
+	// Only applies to files
+	if info.IsDir() {
+		return nil, ErrNotApplicable
+	}
+
+	// Must be executable
+	if ok, err := isExecutable(info); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, ErrNotApplicable
+	}
+
+	// Must start with shebang
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	buffer := make([]byte, 2)
+	if _, err := f.Read(buffer); err != nil {
+		return nil, err
+	}
+	if string(buffer) != "#!" {
+		return nil, ErrNotApplicable // Not a shell script
+	}
+
+	return &shellScriptCommand{
+		executableCommand: executableCommand{
+			parent:       parent,
+			path:         path,
+			name:         filepath.Base(path),
+			discoveredIn: filepath.Dir(path),
+			executor:     d.Executor(),
+		},
+	}, nil
+}
+
+// shellScriptCommand implements the Command interface for shell scripts that use magic comments.
+// It extends executableCommand but overrides Summary() and Help() to read magic comments
+// instead of executing with flags.
+type shellScriptCommand struct {
+	executableCommand
+}
+
+func (cmd *shellScriptCommand) Summary() (string, error) {
+	if cmd.summary != nil {
+		return *cmd.summary, nil
+	}
+
+	return readSummaryFromShellScript(cmd)
+}
+
+func (cmd *shellScriptCommand) Help() (string, error) {
+	return readHelpFromShellScript(cmd)
+}

--- a/contract_standalone_executable.go
+++ b/contract_standalone_executable.go
@@ -1,0 +1,34 @@
+package exoskeleton
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// StandaloneExecutableContract handles executable files that respond to --summary and --help.
+//
+// Note: This contract should be ordered AFTER ScriptCommandContract and ExecutableModuleContract
+// in the contract list, as it matches all executable files.
+type StandaloneExecutableContract struct{}
+
+func (c *StandaloneExecutableContract) BuildCommand(path string, info fs.DirEntry, parent Module, d DiscoveryContext) (Command, error) {
+	// Only applies to files
+	if info.IsDir() {
+		return nil, ErrNotApplicable
+	}
+
+	// Must be executable
+	if ok, err := isExecutable(info); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, ErrNotApplicable
+	}
+
+	return &executableCommand{
+		parent:       parent,
+		path:         path,
+		name:         filepath.Base(path),
+		discoveredIn: filepath.Dir(path),
+		executor:     d.Executor(),
+	}, nil
+}

--- a/contract_test.go
+++ b/contract_test.go
@@ -1,6 +1,8 @@
 package exoskeleton
 
 import (
+	"io/fs"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -41,4 +43,103 @@ func TestGetMessageFromExecutionWithArgs(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "a\nb\n--summary", output)
+}
+
+// TestWithContractsOption verifies that WithContracts replaces the contracts.
+func TestWithContractsOption(t *testing.T) {
+	// Create a custom contract that only matches files named "custom"
+	customContract := &testContract{
+		name: "custom-only",
+		matches: func(path string, info fs.DirEntry) bool {
+			return filepath.Base(path) == "custom"
+		},
+	}
+
+	e := &Entrypoint{
+		contracts: defaultContracts(),
+	}
+
+	// Apply WithContracts
+	WithContracts(customContract).Apply(e)
+
+	// Verify contracts were replaced
+	if len(e.contracts) != 1 {
+		t.Errorf("expected 1 contract, got %d", len(e.contracts))
+	}
+}
+
+// TestContractOrder verifies that contracts are tried in order.
+func TestContractOrder(t *testing.T) {
+	matchAllCalled := false
+	matchNoneCalled := false
+
+	// First contract matches everything
+	matchAll := &testContract{
+		name: "match-all",
+		matches: func(path string, info fs.DirEntry) bool {
+			matchAllCalled = true
+			return true
+		},
+	}
+
+	// Second contract should never be reached
+	matchNone := &testContract{
+		name: "match-none",
+		matches: func(path string, info fs.DirEntry) bool {
+			matchNoneCalled = true
+			return false
+		},
+	}
+
+	// Build a fake discoverer
+	d := &discoverer{
+		maxDepth:  -1,
+		contracts: []Contract{matchAll, matchNone},
+	}
+
+	// Try to build a command using a real file
+	path := filepath.Join(fixtures, "hello")
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Failed to stat test file: %v", err)
+	}
+	entry := fs.FileInfoToDirEntry(info)
+
+	_, err = d.buildCommand(fixtures, nil, entry)
+	if err != nil {
+		t.Fatalf("buildCommand failed: %v", err)
+	}
+
+	// Verify first contract was called
+	if !matchAllCalled {
+		t.Error("first contract (match-all) was not called")
+	}
+
+	// Verify second contract was NOT called (first one matched)
+	if matchNoneCalled {
+		t.Error("second contract (match-none) should not be tried when first matches")
+	}
+}
+
+// testContract is a simple contract for testing.
+type testContract struct {
+	name    string
+	matches func(path string, info fs.DirEntry) bool
+}
+
+func (c *testContract) BuildCommand(path string, info fs.DirEntry, parent Module, d DiscoveryContext) (Command, error) {
+	if c.matches != nil && !c.matches(path, info) {
+		return nil, ErrNotApplicable
+	}
+	// Return nil command for testing purposes
+	return nil, nil
+}
+
+func defaultContracts() []Contract {
+	return []Contract{
+		&DirectoryContract{MetadataFilename: ".exoskeleton"},
+		&ExecutableContract{},
+		&ShellScriptContract{},
+		&StandaloneExecutableContract{},
+	}
 }

--- a/directory_module.go
+++ b/directory_module.go
@@ -9,7 +9,7 @@ import (
 type directoryModule struct {
 	executableCommand
 	cmds       Commands
-	discoverer discoverer
+	discoverer DiscoveryContext
 }
 
 func (m *directoryModule) Exec(e *Entrypoint, args, env []string) error {
@@ -29,8 +29,8 @@ func (m *directoryModule) Help() (string, error) {
 }
 
 func (m *directoryModule) Subcommands() (Commands, error) {
-	if m.cmds == nil {
-		m.discoverer.discoverIn(filepath.Dir(m.path), m, &m.cmds)
+	if m.cmds == nil && m.discoverer != nil {
+		m.cmds, _ = m.discoverer.DiscoverIn(filepath.Dir(m.path), m)
 		// TODO: return errors from discovery
 	}
 

--- a/doc.go
+++ b/doc.go
@@ -41,4 +41,24 @@
 //	   Run example help <command> to print information on a specific command.
 //
 //	And running `example ls` will forward execution to `~/libexec/ls`.
+//
+// # Discovery Contracts
+//
+// Exoskeleton uses a contract system to determine how commands and modules are
+// discovered and built. Four default contracts are provided:
+//
+//   - DirectoryModuleContract: Directories containing a .exoskeleton file
+//   - ExecutableModuleContract: Executables with .exoskeleton extension
+//   - ScriptCommandContract: Shell scripts with magic comments (# SUMMARY:, # HELP:)
+//   - ExecutableCommandContract: Executables that respond to --summary and --help
+//
+// Users can customize discovery by providing their own contracts via WithContracts():
+//
+//	e, _ := exoskeleton.New(
+//	    paths,
+//	    exoskeleton.WithContracts(
+//	        &MyCustomContract{},
+//	        &exoskeleton.DirectoryModuleContract{},
+//	    ),
+//	)
 package exoskeleton

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -47,6 +47,7 @@ type Entrypoint struct {
 	executor                 ExecutorFunc
 	cmdsToAppend             []Command
 	cmdsToPrepend            []Command
+	contracts                []Contract
 }
 
 func (e *Entrypoint) Parent() Module                 { return nil }
@@ -95,6 +96,18 @@ func New(paths []string, options ...Option) (*Entrypoint, error) {
 
 	for _, op := range options {
 		op.Apply(self)
+	}
+
+	if len(self.contracts) == 0 {
+		self.contracts =
+			[]Contract{
+				&DirectoryContract{
+					MetadataFilename: self.moduleMetadataFilename,
+				},
+				&ExecutableContract{},
+				&ShellScriptContract{},
+				&StandaloneExecutableContract{},
+			}
 	}
 
 	// user-provided options may have overridden Name()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/square/exoskeleton
 go 1.19
 
 require (
-	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.7.0
 	github.com/square/exit v1.1.0
 	github.com/stretchr/testify v1.8.1
@@ -14,6 +13,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -22,8 +20,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/help_cmd_test.go
+++ b/help_cmd_test.go
@@ -8,7 +8,12 @@ import (
 )
 
 func TestHelpForWithMagicComment(t *testing.T) {
-	cmd := &executableCommand{path: filepath.Join(fixtures, "edge-cases", "help-from-magic-comments"), executor: defaultExecutor}
+	cmd := &shellScriptCommand{
+		executableCommand: executableCommand{
+			path:     filepath.Join(fixtures, "edge-cases", "help-from-magic-comments"),
+			executor: defaultExecutor,
+		},
+	}
 	entrypoint := &Entrypoint{cmds: Commands{cmd}}
 	help, err := entrypoint.helpFor(cmd, nil)
 

--- a/options.go
+++ b/options.go
@@ -141,3 +141,15 @@ func WithExecutor(value ExecutorFunc) Option {
 func WithModuleMetadataFilename(value string) Option {
 	return (optionFunc)(func(e *Entrypoint) { e.moduleMetadataFilename = value })
 }
+
+// WithContracts sets the contracts used during discovery.
+// Contracts are tried in order; the first that doesn't return ErrNotApplicable builds the command.
+//
+// The default contracts are:
+//  1. DirectoryContract (directories that contain the module metadata file)
+//  2. ExecutableContract (executables with .exoskeleton extension which must implement --describe-commands)
+//  3. ShellScriptContract (shell scripts with magic comments)
+//  4. StandaloneExecutableContract (all other executables which must implement --summary)
+func WithContracts(contracts ...Contract) Option {
+	return (optionFunc)(func(e *Entrypoint) { e.contracts = contracts })
+}


### PR DESCRIPTION
For the most part, this splits some procedural logic in `discovery.go` into four contracts that are tested in order. These are:

| Contract | Description |
|:--- |:--- |
| `DirectoryContract` | a directory that contains the module metadata file |
| `ExecutableContract` | an executable the has the extension `.exoskeleton` and responds to `--describe-commands` |
| `ShellScriptContract` |  a shell script can provide its summary and help via magic comments |
| `StandaloneExecutableContract` | any other executable is expected to respond to `--summary` |

This refactor does two things:
1. It makes these four contracts explicit concepts
2. It allows clients to control support for each

There is one (known) behavioral change: [the first to bytes of executables are read eagerly](https://github.com/square/exoskeleton/pull/48#discussion_r2654224344). This incurs a cost of 80µs per command (or 19ms for 240 commands) — so far I'm not concerned.