### PR TITLE
feat: add command alias support

### DIFF
--- a/builtin_command.go
+++ b/builtin_command.go
@@ -13,6 +13,7 @@ type builtinCommand struct {
 func (c *builtinCommand) Parent() Command          { return c.parent }
 func (c *builtinCommand) Path() string             { return c.parent.Path() }
 func (c *builtinCommand) Name() string             { return c.definition.Name }
+func (c *builtinCommand) Aliases() []string        { return nil }
 func (c *builtinCommand) Summary() (string, error) { return c.definition.Summary, nil }
 func (c *builtinCommand) Help() (string, error)    { return c.definition.Help, nil }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -22,6 +22,7 @@ type mockCommand struct {
 func (m *mockCommand) Parent() Command                            { return nil }
 func (m *mockCommand) Path() string                               { return m.path }
 func (m *mockCommand) Name() string                               { return filepath.Base(m.path) }
+func (m *mockCommand) Aliases() []string                          { return nil }
 func (m *mockCommand) Subcommands() (Commands, error)             { return nil, nil }
 func (m *mockCommand) Summary() (string, error)                   { return "", nil }
 func (m *mockCommand) Help() (string, error)                      { return "", nil }

--- a/command.go
+++ b/command.go
@@ -35,6 +35,10 @@ type Command interface {
 	// It is used by the built-in command 'complete' which provides shell completions.
 	Complete(e *Entrypoint, args, env []string) ([]string, shellcomp.Directive, error)
 
+	// Aliases returns alternative names for the command.
+	// Returns nil for commands without aliases.
+	Aliases() []string
+
 	// Summary returns the (short!) description of the command to be displayed
 	// in menus.
 	//

--- a/commands.go
+++ b/commands.go
@@ -12,14 +12,9 @@ func (c Commands) Find(cmdName string) Command {
 		if cmd.Name() == cmdName {
 			return cmd
 		}
-	}
-	// Fall back to checking aliases
-	for _, cmd := range c {
-		if ec, ok := cmd.(*executableCommand); ok {
-			for _, alias := range ec.aliases {
-				if alias == cmdName {
-					return cmd
-				}
+		for _, alias := range cmd.Aliases() {
+			if alias == cmdName {
+				return cmd
 			}
 		}
 	}

--- a/commands.go
+++ b/commands.go
@@ -6,11 +6,21 @@ import (
 
 type Commands []Command
 
-// Find returns the first command with a given name.
+// Find returns the first command with a given name or alias.
 func (c Commands) Find(cmdName string) Command {
 	for _, cmd := range c {
 		if cmd.Name() == cmdName {
 			return cmd
+		}
+	}
+	// Fall back to checking aliases
+	for _, cmd := range c {
+		if ec, ok := cmd.(*executableCommand); ok {
+			for _, alias := range ec.aliases {
+				if alias == cmdName {
+					return cmd
+				}
+			}
 		}
 	}
 	return nil

--- a/commands_test.go
+++ b/commands_test.go
@@ -19,6 +19,46 @@ func TestFind(t *testing.T) {
 	assert.Equal(t, nil, cmds.Find("c"))
 }
 
+func TestFindByAlias(t *testing.T) {
+	remove := &executableCommand{name: "remove", aliases: []string{"rm", "del"}}
+	add := &executableCommand{name: "add"}
+	cmds := Commands{remove, add}
+
+	// Find by name still works
+	assert.Equal(t, remove, cmds.Find("remove"))
+	assert.Equal(t, add, cmds.Find("add"))
+
+	// Find by alias returns the canonical command
+	assert.Equal(t, remove, cmds.Find("rm"))
+	assert.Equal(t, remove, cmds.Find("del"))
+
+	// Unknown names still return nil
+	assert.Equal(t, nil, cmds.Find("unknown"))
+}
+
+func TestFindNameTakesPrecedenceOverAlias(t *testing.T) {
+	// If a command's name matches, it wins even if another command has it as an alias
+	list := &executableCommand{name: "list"}
+	show := &executableCommand{name: "show", aliases: []string{"list"}}
+	cmds := Commands{list, show}
+
+	// "list" matches the name of the first command, not the alias of the second
+	assert.Equal(t, list, cmds.Find("list"))
+	assert.Equal(t, show, cmds.Find("show"))
+}
+
+func TestFindNameBeatsAliasRegardlessOfOrder(t *testing.T) {
+	// The command with the alias comes FIRST — a single-pass implementation
+	// would incorrectly return show here. The two-pass approach ensures the
+	// canonical name always wins.
+	show := &executableCommand{name: "show", aliases: []string{"list"}}
+	list := &executableCommand{name: "list"}
+	cmds := Commands{show, list}
+
+	assert.Equal(t, list, cmds.Find("list"))
+	assert.Equal(t, show, cmds.Find("show"))
+}
+
 func TestExpand(t *testing.T) {
 	a := &executableCommand{name: "a"}
 	b := &directoryCommand{executableCommand: executableCommand{name: "b"}}

--- a/commands_test.go
+++ b/commands_test.go
@@ -36,26 +36,26 @@ func TestFindByAlias(t *testing.T) {
 	assert.Equal(t, nil, cmds.Find("unknown"))
 }
 
-func TestFindNameTakesPrecedenceOverAlias(t *testing.T) {
-	// If a command's name matches, it wins even if another command has it as an alias
+func TestFindEarlierNameBeatsLaterAlias(t *testing.T) {
+	// When a command discovered earlier has the name and a later command
+	// has it as an alias, the earlier command wins by discovery order.
 	list := &executableCommand{name: "list"}
 	show := &executableCommand{name: "show", aliases: []string{"list"}}
 	cmds := Commands{list, show}
 
-	// "list" matches the name of the first command, not the alias of the second
 	assert.Equal(t, list, cmds.Find("list"))
 	assert.Equal(t, show, cmds.Find("show"))
 }
 
-func TestFindNameBeatsAliasRegardlessOfOrder(t *testing.T) {
-	// The command with the alias comes FIRST — a single-pass implementation
-	// would incorrectly return show here. The two-pass approach ensures the
-	// canonical name always wins.
+func TestFindDiscoveryOrderPrecedence(t *testing.T) {
+	// When a command discovered earlier has an alias that matches the name
+	// of a command discovered later, the earlier command wins — discovery
+	// order is the precedence rule.
 	show := &executableCommand{name: "show", aliases: []string{"list"}}
 	list := &executableCommand{name: "list"}
 	cmds := Commands{show, list}
 
-	assert.Equal(t, list, cmds.Find("list"))
+	assert.Equal(t, show, cmds.Find("list"))
 	assert.Equal(t, show, cmds.Find("show"))
 }
 

--- a/completions.go
+++ b/completions.go
@@ -54,12 +54,11 @@ func (c Commands) completionsFor(args []string) ([]string, shellcomp.Directive, 
 
 	if len(args) > 0 {
 		toComplete := args[0]
-		var name string
 
 		seen := make(map[string]bool)
 
 		for _, subcmd := range c {
-			name = subcmd.Name()
+			name := subcmd.Name()
 
 			if seen[name] {
 				continue
@@ -68,6 +67,16 @@ func (c Commands) completionsFor(args []string) ([]string, shellcomp.Directive, 
 
 			if strings.HasPrefix(name, toComplete) {
 				completions = append(completions, name)
+			}
+
+			// Also complete aliases
+			if ec, ok := subcmd.(*executableCommand); ok {
+				for _, alias := range ec.aliases {
+					if !seen[alias] && strings.HasPrefix(alias, toComplete) {
+						completions = append(completions, alias)
+						seen[alias] = true
+					}
+				}
 			}
 		}
 	}

--- a/completions.go
+++ b/completions.go
@@ -69,13 +69,10 @@ func (c Commands) completionsFor(args []string) ([]string, shellcomp.Directive, 
 				completions = append(completions, name)
 			}
 
-			// Also complete aliases
-			if ec, ok := subcmd.(*executableCommand); ok {
-				for _, alias := range ec.aliases {
-					if !seen[alias] && strings.HasPrefix(alias, toComplete) {
-						completions = append(completions, alias)
-						seen[alias] = true
-					}
+			for _, alias := range subcmd.Aliases() {
+				if !seen[alias] && strings.HasPrefix(alias, toComplete) {
+					completions = append(completions, alias)
+					seen[alias] = true
 				}
 			}
 		}

--- a/contract.go
+++ b/contract.go
@@ -160,6 +160,7 @@ func parseDescribeCommands(cmd *executableCommand, out string) (*commandDescript
 
 type commandDescriptor struct {
 	Name     string               `json:"name"`
+	Aliases  []string             `json:"aliases,omitempty"`
 	Summary  *string              `json:"summary,omitempty"`
 	Commands []*commandDescriptor `json:"commands,omitempty"`
 }

--- a/contract_test.go
+++ b/contract_test.go
@@ -45,6 +45,50 @@ func TestGetMessageFromExecutionWithArgs(t *testing.T) {
 	assert.Equal(t, "a\nb\n--summary", output)
 }
 
+func TestParseDescribeCommandsWithAliases(t *testing.T) {
+	cmd := &executableCommand{path: "/test"}
+	out := `{
+		"name": "root",
+		"commands": [
+			{"name": "remove", "aliases": ["rm", "del"], "summary": "Remove something"},
+			{"name": "add", "summary": "Add something"}
+		]
+	}`
+
+	descriptor, err := parseDescribeCommands(cmd, out)
+	assert.NoError(t, err)
+	assert.Equal(t, "root", descriptor.Name)
+	assert.Len(t, descriptor.Commands, 2)
+	assert.Equal(t, []string{"rm", "del"}, descriptor.Commands[0].Aliases)
+	assert.Nil(t, descriptor.Commands[1].Aliases)
+}
+
+func TestToCommandsPropagatesAliases(t *testing.T) {
+	parent := &executableCommand{
+		path:     "/test",
+		executor: defaultExecutor,
+		cache:    nullCache{},
+	}
+
+	summary := "Remove something"
+	descriptors := []*commandDescriptor{
+		{Name: "remove", Aliases: []string{"rm"}, Summary: &summary},
+		{Name: "add"},
+	}
+
+	cmds := toCommands(parent, descriptors, nil, &discoverer{maxDepth: 0})
+
+	assert.Len(t, cmds, 2)
+
+	removeCmd := cmds[0].(*executableCommand)
+	assert.Equal(t, "remove", removeCmd.name)
+	assert.Equal(t, []string{"rm"}, removeCmd.aliases)
+
+	addCmd := cmds[1].(*executableCommand)
+	assert.Equal(t, "add", addCmd.name)
+	assert.Nil(t, addCmd.aliases)
+}
+
 // TestWithContractsOption verifies that WithContracts replaces the contracts.
 func TestWithContractsOption(t *testing.T) {
 	// Create a custom contract that only matches files named "custom"

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -54,6 +54,7 @@ type Entrypoint struct {
 func (e *Entrypoint) Parent() Command                { return nil }
 func (e *Entrypoint) Path() string                   { return e.path }
 func (e *Entrypoint) Name() string                   { return e.name }
+func (e *Entrypoint) Aliases() []string              { return nil }
 func (e *Entrypoint) Summary() (string, error)       { panic("Unused") }
 func (e *Entrypoint) Help() (string, error)          { panic("Unused") }
 func (e *Entrypoint) Subcommands() (Commands, error) { return e.cmds, nil }

--- a/executable_command.go
+++ b/executable_command.go
@@ -27,6 +27,7 @@ type executableCommand struct {
 func (cmd *executableCommand) Parent() Command      { return cmd.parent }
 func (cmd *executableCommand) Path() string         { return cmd.path }
 func (cmd *executableCommand) Name() string         { return cmd.name }
+func (cmd *executableCommand) Aliases() []string    { return cmd.aliases }
 func (cmd *executableCommand) DiscoveredIn() string { return cmd.discoveredIn }
 
 // Command returns an exec.Cmd that will run the executable with the given arguments.

--- a/executable_command.go
+++ b/executable_command.go
@@ -14,6 +14,7 @@ type executableCommand struct {
 	parent       Command
 	path         string
 	name         string
+	aliases      []string
 	args         []string
 	summary      *string
 	discoveredIn string
@@ -161,6 +162,7 @@ func toCommands(parent *executableCommand, descriptors []*commandDescriptor, arg
 			path:         parent.path,
 			args:         append(args, descriptor.Name),
 			name:         descriptor.Name,
+			aliases:      descriptor.Aliases,
 			summary:      descriptor.Summary,
 			executor:     parent.executor,
 			cache:        parent.cache,

--- a/identification_test.go
+++ b/identification_test.go
@@ -7,6 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIdentifyByAlias(t *testing.T) {
+	remove := &executableCommand{name: "remove", aliases: []string{"rm"}}
+	b := &directoryCommand{executableCommand: executableCommand{name: "b"}}
+	sub := &executableCommand{parent: b, name: "sub", aliases: []string{"s"}}
+	b.cmds = Commands{sub}
+
+	help := &builtinCommand{definition: &EmbeddedCommand{Name: `help`}}
+	complete := &builtinCommand{definition: &EmbeddedCommand{Name: `complete`}}
+	entrypoint := &Entrypoint{cmds: Commands{help, complete, remove, b}}
+
+	scenarios := []struct {
+		args         []string
+		expectedCmd  Command
+		expectedArgs []string
+	}{
+		// Alias at top level
+		{[]string{"rm"}, remove, []string{}},
+		{[]string{"rm", "arg", "--flag"}, remove, []string{"arg", "--flag"}},
+
+		// Alias of a subcommand
+		{[]string{"b", "s"}, sub, []string{}},
+		{[]string{"b", "s", "arg"}, sub, []string{"arg"}},
+
+		// Canonical name still works
+		{[]string{"remove"}, remove, []string{}},
+		{[]string{"b", "sub"}, sub, []string{}},
+	}
+
+	for _, s := range scenarios {
+		cmd, rest, err := entrypoint.Identify(s.args)
+		assert.NoError(t, err, fmt.Sprintf("Identify(%v)", s.args))
+		assert.Equal(t, s.expectedCmd, cmd, fmt.Sprintf("Identify(%v)", s.args))
+		assert.Equal(t, s.expectedArgs, rest, fmt.Sprintf("Identify(%v)", s.args))
+	}
+}
+
 func TestIdentify(t *testing.T) {
 	// all
 	// ├── a

--- a/null_command.go
+++ b/null_command.go
@@ -14,6 +14,7 @@ type nullCommand struct {
 func (n nullCommand) Parent() Command          { return n.parent }
 func (_ nullCommand) Path() string             { return "" }
 func (n nullCommand) Name() string             { return n.name }
+func (_ nullCommand) Aliases() []string        { return nil }
 func (_ nullCommand) Summary() (string, error) { panic("Unused") }
 func (_ nullCommand) Help() (string, error)    { panic("Unused") }
 


### PR DESCRIPTION
🤖 _This PR description was generated by AI._

## Problem

Cobra-based plugins can register command aliases (e.g., `sq agents` → `sq skills`), but the exoskeleton framework does not propagate or resolve them. Users who type an alias get "unknown command" even though the plugin declares the alias.

## Solution

Commits follow dependency order:

1. **Add command alias support** — Added `Aliases []string` field to `commandDescriptor` (with `omitempty` for backward compatibility), propagated through `toCommands()`, and added tests for parsing and propagation.

2. **Make Aliases part of Command interface** — Promoted `Aliases()` from a private field on `executableCommand` to a method on the `Command` interface. All concrete types (`builtinCommand`, `directoryCommand`, `nullCommand`, `Entrypoint`) implement it. `Find()` uses a single pass checking both name and aliases inline (discovery-order precedence). Completions use the interface method instead of type assertions.

## Key Design Decisions

- **`Aliases()` on the interface**: Any `Command` implementation can declare aliases, not just `executableCommand`. This keeps the door open for aliased built-in commands.
- **Single-pass `Find()` with discovery-order precedence**: A command discovered earlier wins, whether matched by name or alias. No special "names beat aliases" rule — ordering is the sole precedence mechanism.
- **Tab completion includes aliases**: Aliases appear as completion suggestions alongside canonical names, with deduplication.

## Companion Change

- **sqcobra bridge**: squareup/sq#340 (populates `Aliases` from Cobra command metadata)

## Backward Compatibility

Fully backward compatible — `Aliases` is omitted from JSON when empty (`omitempty`), so existing plugins and descriptors are unaffected.