### PR TITLE
feat: Add `defaultCommand` to the CLI contract

### DIFF
--- a/builtin_command.go
+++ b/builtin_command.go
@@ -34,6 +34,16 @@ func (c *builtinCommand) Complete(e *Entrypoint, args, env []string) ([]string, 
 	return []string{}, shellcomp.DirectiveNoFileComp, nil
 }
 
+func (c *builtinCommand) DefaultSubcommand() Command {
+	if c.definition.DefaultCommand == "" {
+		return nil
+	}
+	if cmds, err := c.Subcommands(); err == nil {
+		return cmds.Find(c.definition.DefaultCommand)
+	}
+	return nil
+}
+
 func (c *builtinCommand) Subcommands() (Commands, error) {
 	return c.subcommands, nil
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -23,6 +23,7 @@ func (m *mockCommand) Parent() Command                            { return nil }
 func (m *mockCommand) Path() string                               { return m.path }
 func (m *mockCommand) Name() string                               { return filepath.Base(m.path) }
 func (m *mockCommand) Aliases() []string                          { return nil }
+func (m *mockCommand) DefaultSubcommand() Command                 { return nil }
 func (m *mockCommand) Subcommands() (Commands, error)             { return nil, nil }
 func (m *mockCommand) Summary() (string, error)                   { return "", nil }
 func (m *mockCommand) Help() (string, error)                      { return "", nil }

--- a/command.go
+++ b/command.go
@@ -58,4 +58,9 @@ type Command interface {
 	// Returns a CommandError if the command does not fulfill the contract
 	// for providing its subcommands.
 	Subcommands() (Commands, error)
+
+	// DefaultSubcommand returns the default subcommand for this command, if one
+	// is configured. Returns nil if no default is set or the named default does
+	// not match any subcommand.
+	DefaultSubcommand() Command
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -59,6 +59,39 @@ func TestFindDiscoveryOrderPrecedence(t *testing.T) {
 	assert.Equal(t, show, cmds.Find("show"))
 }
 
+func TestDefaultSubcommand(t *testing.T) {
+	a := &executableCommand{name: "a"}
+	b := &executableCommand{name: "b"}
+	parent := &executableCommand{
+		name:              "parent",
+		cmds:              Commands{a, b},
+		defaultSubcommand: "b",
+		discoverer:        &discoverer{maxDepth: 0},
+	}
+	assert.Equal(t, b, parent.DefaultSubcommand())
+}
+
+func TestDefaultSubcommandWhenUnset(t *testing.T) {
+	a := &executableCommand{name: "a"}
+	parent := &executableCommand{
+		name:       "parent",
+		cmds:       Commands{a},
+		discoverer: &discoverer{maxDepth: 0},
+	}
+	assert.Nil(t, parent.DefaultSubcommand())
+}
+
+func TestDefaultSubcommandWhenNameDoesNotMatch(t *testing.T) {
+	a := &executableCommand{name: "a"}
+	parent := &executableCommand{
+		name:              "parent",
+		cmds:              Commands{a},
+		defaultSubcommand: "z",
+		discoverer:        &discoverer{maxDepth: 0},
+	}
+	assert.Nil(t, parent.DefaultSubcommand())
+}
+
 func TestExpand(t *testing.T) {
 	a := &executableCommand{name: "a"}
 	b := &directoryCommand{executableCommand: executableCommand{name: "b"}}

--- a/contract.go
+++ b/contract.go
@@ -159,10 +159,11 @@ func parseDescribeCommands(cmd *executableCommand, out string) (*commandDescript
 }
 
 type commandDescriptor struct {
-	Name     string               `json:"name"`
-	Aliases  []string             `json:"aliases,omitempty"`
-	Summary  *string              `json:"summary,omitempty"`
-	Commands []*commandDescriptor `json:"commands,omitempty"`
+	Name           string               `json:"name"`
+	Aliases        []string             `json:"aliases,omitempty"`
+	Summary        *string              `json:"summary,omitempty"`
+	Commands       []*commandDescriptor `json:"commands,omitempty"`
+	DefaultCommand string               `json:"defaultCommand,omitempty"`
 }
 
 func readSummaryFromShellScript(cmd *shellScriptCommand) (string, error) {

--- a/contract_test.go
+++ b/contract_test.go
@@ -89,6 +89,29 @@ func TestToCommandsPropagatesAliases(t *testing.T) {
 	assert.Nil(t, addCmd.aliases)
 }
 
+func TestDefaultCommandFromDescriptor(t *testing.T) {
+	parent := &executableCommand{path: "/test", executor: defaultExecutor, cache: nullCache{}}
+	out := `{
+		"name": "root",
+		"defaultCommand": "b",
+		"commands": [
+			{"name": "a"},
+			{"name": "b"}
+		]
+	}`
+
+	descriptor, err := parseDescribeCommands(parent, out)
+	assert.NoError(t, err)
+	assert.Equal(t, "b", descriptor.DefaultCommand)
+
+	cmds := toCommands(parent, descriptor.Commands, nil, &discoverer{maxDepth: 0})
+	parent.cmds = cmds
+	parent.defaultSubcommand = descriptor.DefaultCommand
+	parent.discoverer = &discoverer{maxDepth: 0}
+
+	assert.Equal(t, "b", parent.DefaultSubcommand().Name())
+}
+
 // TestWithContractsOption verifies that WithContracts replaces the contracts.
 func TestWithContractsOption(t *testing.T) {
 	// Create a custom contract that only matches files named "custom"

--- a/directory_command.go
+++ b/directory_command.go
@@ -30,6 +30,8 @@ func (m *directoryCommand) Help() (string, error) {
 	panic("Unused")
 }
 
+func (m *directoryCommand) DefaultSubcommand() Command { return nil }
+
 func (m *directoryCommand) Subcommands() (Commands, error) {
 	if m.cmds == nil && m.discoverer != nil {
 		m.cmds, _ = m.discoverer.DiscoverIn(filepath.Dir(m.path), m)

--- a/entrypoint.go
+++ b/entrypoint.go
@@ -57,6 +57,7 @@ func (e *Entrypoint) Name() string                   { return e.name }
 func (e *Entrypoint) Aliases() []string              { return nil }
 func (e *Entrypoint) Summary() (string, error)       { panic("Unused") }
 func (e *Entrypoint) Help() (string, error)          { panic("Unused") }
+func (e *Entrypoint) DefaultSubcommand() Command     { return nil }
 func (e *Entrypoint) Subcommands() (Commands, error) { return e.cmds, nil }
 
 // New searches the given paths and constructs an Entrypoint with a list of commands

--- a/executable_command.go
+++ b/executable_command.go
@@ -11,17 +11,18 @@ import (
 
 // executableCommand implements the Command interface for a file that can be executed.
 type executableCommand struct {
-	parent       Command
-	path         string
-	name         string
-	aliases      []string
-	args         []string
-	summary      *string
-	discoveredIn string
-	executor     ExecutorFunc
-	cmds         Commands
-	discoverer   DiscoveryContext
-	cache        Cache
+	parent            Command
+	path              string
+	name              string
+	aliases           []string
+	args              []string
+	summary           *string
+	discoveredIn      string
+	executor          ExecutorFunc
+	cmds              Commands
+	defaultSubcommand string
+	discoverer        DiscoveryContext
+	cache             Cache
 }
 
 func (cmd *executableCommand) Parent() Command      { return cmd.parent }
@@ -95,6 +96,16 @@ func (cmd *executableCommand) Help() (string, error) {
 	return readHelpFromExecutable(cmd)
 }
 
+func (cmd *executableCommand) DefaultSubcommand() Command {
+	if cmd.defaultSubcommand == "" {
+		return nil
+	}
+	if cmds, err := cmd.Subcommands(); err == nil {
+		return cmds.Find(cmd.defaultSubcommand)
+	}
+	return nil
+}
+
 // Subcommands returns the list of subcommands for this command.
 // Returns an empty slice for leaf commands.
 func (cmd *executableCommand) Subcommands() (Commands, error) {
@@ -150,6 +161,7 @@ func (cmd *executableCommand) discover() error {
 	}
 
 	cmd.summary = descriptor.Summary
+	cmd.defaultSubcommand = descriptor.DefaultCommand
 	cmd.cmds = toCommands(cmd, descriptor.Commands, nil, cmd.discoverer)
 	return nil
 }
@@ -158,15 +170,16 @@ func toCommands(parent *executableCommand, descriptors []*commandDescriptor, arg
 	cmds := Commands{}
 	for _, descriptor := range descriptors {
 		c := &executableCommand{
-			parent:       parent,
-			discoveredIn: parent.discoveredIn,
-			path:         parent.path,
-			args:         append(args, descriptor.Name),
-			name:         descriptor.Name,
-			aliases:      descriptor.Aliases,
-			summary:      descriptor.Summary,
-			executor:     parent.executor,
-			cache:        parent.cache,
+			parent:            parent,
+			discoveredIn:      parent.discoveredIn,
+			path:              parent.path,
+			args:              append(args, descriptor.Name),
+			name:              descriptor.Name,
+			aliases:           descriptor.Aliases,
+			summary:           descriptor.Summary,
+			defaultSubcommand: descriptor.DefaultCommand,
+			executor:          parent.executor,
+			cache:             parent.cache,
 		}
 
 		if len(descriptor.Commands) > 0 && d.MaxDepth() != 0 {

--- a/identification.go
+++ b/identification.go
@@ -57,6 +57,9 @@ func identify(cmd Command, args []string) (Command, []string, error) {
 	if cmds, err := cmd.Subcommands(); err != nil {
 		return cmd, args, err
 	} else if found := cmds.Find(name); found == nil {
+		if def := cmd.DefaultSubcommand(); def != nil {
+			return def, args, nil
+		}
 		return nullCommand{parent: cmd, name: name}, rest, nil
 	} else if subcmds, err := found.Subcommands(); err != nil {
 		return found, rest, err

--- a/identification_test.go
+++ b/identification_test.go
@@ -58,12 +58,18 @@ func TestIdentify(t *testing.T) {
 	b.cmds = Commands{c, d}
 	d.cmds = Commands{e}
 
+	// f is a module with a default subcommand
+	f := &builtinCommand{definition: &EmbeddedCommand{Name: "f", DefaultCommand: "g"}}
+	g := &builtinCommand{parent: f, definition: &EmbeddedCommand{Name: "g"}}
+	h := &builtinCommand{parent: f, definition: &EmbeddedCommand{Name: "h"}}
+	f.subcommands = Commands{g, h}
+
 	// Should never be returned because `a` precedes it.
 	overloaded_a := &executableCommand{name: "a"}
 
 	help := &builtinCommand{definition: &EmbeddedCommand{Name: `help`}}
 	complete := &builtinCommand{definition: &EmbeddedCommand{Name: `complete`}}
-	entrypoint := &Entrypoint{cmds: Commands{help, complete, a, b, overloaded_a}}
+	entrypoint := &Entrypoint{cmds: Commands{help, complete, a, b, f, overloaded_a}}
 
 	scenarios := []struct {
 		args         []string
@@ -99,6 +105,14 @@ func TestIdentify(t *testing.T) {
 
 		// Can invoke a module with a trailing colon
 		{[]string{"b:"}, b, []string{}},
+
+		// DefaultSubcommand is used when a subcommand is not found by name
+		{[]string{"f"}, f, []string{}},
+		{[]string{"f", "--flag"}, f, []string{"--flag"}},
+		{[]string{"f", "g"}, g, []string{}},
+		{[]string{"f", "h"}, h, []string{}},
+		{[]string{"f", "x"}, g, []string{"x"}},
+		{[]string{"f", "x", "arg", "--flag"}, g, []string{"x", "arg", "--flag"}},
 
 		// Identifies `--complete` as `complete`
 		{[]string{"--complete"}, complete, []string{}},

--- a/null_command.go
+++ b/null_command.go
@@ -27,6 +27,8 @@ func (_ nullCommand) Complete(_ *Entrypoint, _, _ []string) ([]string, shellcomp
 	return nil, shellcomp.DirectiveNoFileComp, nil
 }
 
+func (_ nullCommand) DefaultSubcommand() Command { return nil }
+
 func (_ nullCommand) Subcommands() (Commands, error) {
 	return Commands{}, nil
 }

--- a/options.go
+++ b/options.go
@@ -23,12 +23,13 @@ type CompleteFunc func(e *Entrypoint, args, env []string) ([]string, shellcomp.D
 // EmbeddedCommand defines a built-in command that can be added to an Entrypoint
 // (as opposed to an executable external to the Entrypoint).
 type EmbeddedCommand struct {
-	Name     string
-	Summary  string
-	Help     string
-	Exec     ExecFunc
-	Complete CompleteFunc
-	Commands []*EmbeddedCommand
+	Name           string
+	Summary        string
+	Help           string
+	Exec           ExecFunc
+	Complete       CompleteFunc
+	Commands       []*EmbeddedCommand
+	DefaultCommand string
 }
 
 // Apply invokes the optionFunc with the given Entrypoint.


### PR DESCRIPTION
so you can model things like

- `show` is the default subcommand of `git remote`
- `save` is the default subcommand of `git stash`

```javascript
{
  "name": "git", 
  "commands": [
    {
      "name": "remote",
      "defaultCommand": "show",
      "commands:": [
        {
          "name": "show",
          // ...
        }
      ]
    },
    {
      "name": "stash",
      "defaultCommand": "save",
      "commands:": [
        {
          "name": "save",
          // ...
        }
      ]
    },
    // ...
  ]
}
```
